### PR TITLE
[CE-672] Scripts to find, store, promote a plugin with its dependencies

### DIFF
--- a/ucStoreAndPromoteWithDependencies.groovy
+++ b/ucStoreAndPromoteWithDependencies.groovy
@@ -1,0 +1,200 @@
+/*** BEGIN META {
+ "name" : "Store or Promote with dependencies in Custom Update Center",
+ "comment" : "Calculate required dependencies for a Plugin in Custom Update Center. Provide also methods to either 1) Download the plugin with its dependencies or 2) Promote the plugin with its dependencies (Don't use both at once)",
+ "parameters" : [pluginName, pluginVersion, updateCenterFullName],
+ "core": "1.642",
+ "authors" : [
+ { name : "Allan Burdajewicz" }
+ ]
+ } END META**/
+
+import com.cloudbees.jenkins.updates.data.DependencyEntry
+import com.cloudbees.jenkins.updates.data.PluginEntry
+import com.cloudbees.jenkins.updates.versioning.VersionNumber
+import com.cloudbees.plugins.updatecenter.PluginData
+import com.cloudbees.plugins.updatecenter.UpdateCenter
+
+/*************************************************
+ * START Variables:
+ * Change the following variable to suit your need
+ *************************************************/
+
+// Plugin name (example: 'cloudbees-template')
+String pluginName = "${pluginName}"
+// Plugin version (example: '4.26')
+String pluginVersion = "${pluginVersion}"
+// Update center full name (example: 'myFolder/myUc')
+String updateCenterFullName = "${updateCenterFullName}"
+
+/*************************************************
+ * END Variables
+ *************************************************/
+
+/**
+ * Fill a map with required dependencies.
+ * @param updateCenter The update center item
+ * @param name the name of the plugin
+ * @param version the version of the plugin
+ * @param checkedDeps the dependencies already checked
+ * @param requiredDeps the required dependencies (Map being filled)
+ * @param indent indent for log output
+ */
+void fillRequiredDependencies(
+        UpdateCenter updateCenter,
+        String name,
+        String version,
+        Collection<DependencyEntry> checkedDeps,
+        Map<String, PluginEntry> requiredDeps,
+        String indent) {
+
+    PluginData pluginData = updateCenter.getPlugin(name)
+    VersionNumber pluginVersionNumber = new VersionNumber(version)
+
+    /* Retrieve the plugin entry */
+    PluginEntry pluginEntry = pluginData.getVersions().find { entry -> entry.getKey() == pluginVersionNumber}?.getValue()
+
+    if(pluginEntry == null) {
+        println "${indent} Plugin ${pluginData.getName()}:${pluginVersionNumber} not pulled yet. Checking on store and updates."
+        pluginEntry = getSuitableVersion(updateCenter, name, version,"${indent} ")
+    }
+
+    if(pluginEntry != null) {
+        requiredDeps.put(pluginData.getName(), pluginEntry)
+        /* Retrieve required dependencies */
+        pluginEntry.dependencies.findAll{ !it.getOptional() }?.each { dep ->
+            if(!checkedDeps.contains(dep)) {
+                println "${indent} [PULL] Checking dependency: \"name\": \"${dep.getName()}\", \"version\": \"${dep.getVersion()}\", \"optional\": \"${dep.getOptional()}\""
+                checkedDeps.add(dep)
+
+                VersionNumber currentVersionNumber = requiredDeps.get(dep.getName())?.getVersionNumber()
+                if(currentVersionNumber == null || currentVersionNumber.isOlderThan(new VersionNumber(dep.getVersion()))) {
+                    fillRequiredDependencies(updateCenter, dep.getName(), dep.getVersion(), checkedDeps, requiredDeps,"${indent} ")
+                } else {
+                    println "${indent}  Already found a requirement for higher version: ${currentVersionNumber} "
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Return a suitable version/update of a plugin (one equal or more recent). It will pick the most recent one if no exact match found.
+ * @param updateCenter The update center item
+ * @param name the name of the plugin
+ * @param version the version of the plugin
+ * @param indent indent for log output
+ * @return The corresponding entry
+ */
+PluginEntry getSuitableVersion(UpdateCenter updateCenter, String name, String version, String indent) {
+
+    PluginData pluginData = updateCenter.getPlugin(name)
+    VersionNumber pluginVersionNumber = new VersionNumber(version)
+
+    /* Retrieve the plugin entry */
+    PluginEntry pluginEntry = pluginData.getVersions().find { entry -> entry.getKey() == pluginVersionNumber}?.getValue()
+
+    if(pluginEntry != null) {
+        //Found exact match
+        return pluginEntry
+    } else {
+        //Check for more recent versions
+        List<PluginEntry> moreRecentVersions = pluginData.getVersions().findAll {
+            entry -> entry.getKey() >= pluginVersionNumber
+        }.collect {
+            entry -> entry.getValue()
+        }
+
+        if (moreRecentVersions == null || moreRecentVersions.isEmpty()) {
+            println "${indent} Plugin ${pluginData.getName()} does not have any suitable version stored"
+        } else {
+            println "${indent} Requested version not available in store but more recent versions found. Using the latest version ${moreRecentVersions.get(0).getVersion()}."
+            return moreRecentVersions.get(0)
+        }
+
+        // Need to pull, check for updates
+        List<PluginEntry> pluginUpdates  = pluginData.getUpdates().findAll {
+            entry -> entry.getKey() >= pluginVersionNumber
+        }.collect {
+            entry -> entry.getValue()
+        }
+
+        if (pluginUpdates == null || pluginUpdates.isEmpty()) {
+            println "${indent} [ERROR] Plugin ${pluginData.getName()} does not have any suitable updates available for download"
+        } else {
+            PluginEntry toDownload = pluginUpdates.find { it.getVersionNumber() == pluginVersionNumber}
+            if (toDownload == null) {
+                println "${indent} [WARNING] Requested version ${pluginVersionNumber} not available for download but more recent versions found. Using the latest version"
+                toDownload = pluginUpdates.get(0)
+            }
+            println "${indent} [INFO] Requested version ${toDownload.getVersion()} available for download"
+            return toDownload
+        }
+        return null
+    }
+}
+
+UpdateCenter myUC = jenkins.model.Jenkins.instance.getItemByFullName(updateCenterFullName, UpdateCenter.class)
+if(myUC == null) {
+    println "Cannot find UC '${updateCenterFullName}'!"
+}
+
+println "##########\nCalculate required dependencies:\n##########"
+// Construct the dependencies map
+Map<String, PluginEntry> requiredDeps = new HashMap<>()
+fillRequiredDependencies(myUC, pluginName, pluginVersion, new HashSet<DependencyEntry>(), requiredDeps, "")
+
+/*************************************************************
+ * Store With Dependencies: Based on the list calculated above
+ *************************************************************/
+
+/**
+ * Download plugin if not already stored
+ * @param updateCenter the update center item
+ * @param pluginEntries the list of plugin entries to download
+ * @return
+ */
+def downloadPlugins(UpdateCenter updateCenter, Collection<PluginEntry> pluginEntries) {
+    pluginEntries.each { pluginEntry ->
+        PluginData pluginData = updateCenter.getPlugin(pluginEntry.getName())
+        if(pluginData.getVersions().find { entry -> entry.getKey() == pluginEntry.getVersionNumber()} != null) {
+            println " Plugin ${pluginEntry.getName()}:${pluginEntry.getVersionNumber()} is already pulled."
+        } else {
+            println " Pulling plugin version ${pluginEntry.getName()}:${pluginEntry.getVersionNumber()}"
+            updateCenter.downloadPlugin(pluginEntry.getUrl(), pluginEntry.getName(), pluginEntry.getVersion(), pluginEntry.getSha1())
+        }
+    }
+}
+
+println "##########\nDownload required dependencies:\n##########"
+downloadPlugins(myUC, requiredDeps.values())
+
+/***************************************************************
+ * Promote With Dependencies: Based on the list calculated above
+ ***************************************************************/
+
+/**
+ * Promote plugin if not already promoted
+ * @param updateCenter the update center item
+ * @param pluginEntries the list of plugin entries to promote
+ * @return
+ */
+def promotePlugins(UpdateCenter updateCenter, Collection<PluginEntry> pluginEntries) {
+    pluginEntries.each { pluginEntry ->
+        PluginData pluginData = updateCenter.getPlugin(pluginEntry.getName())
+        if(pluginData.getVersions().find { entry -> entry.getKey() == pluginEntry.getVersionNumber()} != null) {
+            if (pluginData.getPromotedVersionNumber() != pluginEntry.getVersionNumber()) {
+                println " Promoting plugin version ${pluginEntry.getName()}:${pluginEntry.getVersionNumber()}"
+                pluginData.setPromotedVersion(pluginEntry.getVersion())
+            } else {
+                println " ${pluginEntry.getName()}:${pluginEntry.getVersionNumber()} is already promoted."
+            }
+        } else {
+            println " Plugin ${pluginEntry.getName()}:${pluginEntry.getVersionNumber()} is not pulled yet."
+        }
+    }
+}
+
+println "##########\nPromote required dependencies:\n##########"
+promotePlugins(myUC, requiredDeps.values())
+
+return

--- a/ucStoreAndPromoteWithDependencies.groovy
+++ b/ucStoreAndPromoteWithDependencies.groovy
@@ -305,7 +305,7 @@ def promotePlugins(UpdateCenter updateCenter, Collection<PluginEntry> pluginEntr
                 println " Is already promoted."
             }
             // Following can be used to promote to the latest
-            // pluginData.setPromotedVersion("PluginData.LATEST_VERSION_STRING")
+            // pluginData.setPromotedVersion(PluginData.LATEST_VERSION_STRING)
         } else {
             println " Is not in store. Run the STORE action first"
         }

--- a/ucStoreAndPromoteWithDependencies.groovy
+++ b/ucStoreAndPromoteWithDependencies.groovy
@@ -28,10 +28,10 @@ import com.google.common.collect.Sets
  */
 String pluginName = "${pluginName}"
 /**
- * The plugin version. Note that if the EXACT version cannot be found in store or for download, the latest
+ * The plugin version. Note: if the EXACT version cannot be found in store or for download, the latest
  * available version will be picked by the script.
  * This can be controlled with ${updateCenterStrategy} but ONLY higher versions are considered suitable.
- * Example: '2.5'
+ * Example: '2.5' or leave empty '' to pick up the latest
  */
 String pluginVersion = "${pluginVersion}"
 /**
@@ -126,7 +126,7 @@ boolean fillRequiredDependencies(
         pluginDownloadableEntry = getSuitableVersionToDownload(pluginData, pluginVersionNumber, downloadStrategy,"${indent} ")
     }
 
-    pluginEntry = pluginDownloadableEntry != null ? pluginDownloadableEntry : pluginStoredEntry
+    PluginEntry pluginEntry = pluginDownloadableEntry != null ? pluginDownloadableEntry : pluginStoredEntry
 
     boolean consistent = true
     if(pluginEntry != null) {

--- a/ucStoreAndPromoteWithDependencies.groovy
+++ b/ucStoreAndPromoteWithDependencies.groovy
@@ -319,6 +319,7 @@ def promotePlugins(UpdateCenter updateCenter, Collection<PluginEntry> pluginEntr
 UpdateCenter myUC = jenkins.model.Jenkins.instance.getItemByFullName(updateCenterFullName, UpdateCenter.class)
 if(myUC == null) {
     println "Cannot find UC '${updateCenterFullName}'!"
+    return
 }
 
 println "\n----------------------------------\nCalculate required dependencies:\n----------------------------------"

--- a/ucStoreAndPromoteWithDependencies.groovy
+++ b/ucStoreAndPromoteWithDependencies.groovy
@@ -1,7 +1,7 @@
 /*** BEGIN META {
  "name" : "Store or Promote with dependencies in Custom Update Center",
  "comment" : "Calculate required dependencies for a Plugin in Custom Update Center. Provide also methods to either 1) Download the plugin with its dependencies or 2) Promote the plugin with its dependencies (Don't use both at once)",
- "parameters" : [pluginName, pluginVersion, updateCenterFullName],
+ "parameters" : [pluginName, pluginVersion, updateCenterFullName, updateCenterAction, updateCenterActionDryRun, updateCenterStrategy],
  "core": "1.642",
  "authors" : [
  { name : "Allan Burdajewicz" }
@@ -14,134 +14,175 @@ import com.cloudbees.jenkins.updates.versioning.VersionNumber
 import com.cloudbees.plugins.updatecenter.PluginData
 import com.cloudbees.plugins.updatecenter.UpdateCenter
 
-/*************************************************
- * START Variables:
- * Change the following variable to suit your need
- *************************************************/
-
-// Plugin name (example: 'cloudbees-template')
-String pluginName = "${pluginName}"
-// Plugin version (example: '4.26')
-String pluginVersion = "${pluginVersion}"
-// Update center full name (example: 'myFolder/myUc')
-String updateCenterFullName = "${updateCenterFullName}"
-
-/*************************************************
- * END Variables
- *************************************************/
-
 /**
  * Fill a map with required dependencies.
  * @param updateCenter The update center item
  * @param name the name of the plugin
  * @param version the version of the plugin
+ * @param pickStrategy strategy to apply when exact version is not available
  * @param checkedDeps the dependencies already checked
  * @param requiredDeps the required dependencies (Map being filled)
  * @param indent indent for log output
  */
-void fillRequiredDependencies(
+boolean fillRequiredDependencies(
         UpdateCenter updateCenter,
         String name,
         String version,
+        String pickStrategy,
         Collection<DependencyEntry> checkedDeps,
         Map<String, PluginEntry> requiredDeps,
+        String indent) {
+
+    boolean consistent = true
+    PluginData pluginData = updateCenter.getPlugin(name)
+    if(pluginData == null) {
+        println "${indent}[ERROR]Plugin [${name}] does not exists in this update center!"
+        return false
+    }
+    VersionNumber pluginVersionNumber = new VersionNumber(version)
+    println "${indent}[${pluginData.name}:${pluginVersionNumber}]"
+
+    /* Retrieve the plugin entry */
+    println "${indent} Checking available versions in store..."
+    PluginEntry pluginEntry = getSuitableVersionInStore(updateCenter, name, version, pickStrategy,"${indent} ")
+
+    if(pluginEntry == null || pickStrategy == "LATEST_STRICT") {
+        println "${indent} Checking available versions for download..."
+        pluginEntry = getSuitableVersionToDownload(updateCenter, name, version, pickStrategy,"${indent} ")
+    }
+
+    if(pluginEntry != null) {
+        println "${indent} [PICK] Suitable version(s) found [${pluginEntry.name}:${pluginEntry.versionNumber}]"
+        /* Retrieve required dependencies */
+        pluginEntry.dependencies.findAll{!checkedDeps.contains(it)}.each { dep ->
+            checkedDeps.add(dep)
+            println "${indent} Checking dependency: \"name\": \"${dep.name}\", \"version\": \"${dep.version}\", \"optional\": \"${dep.getOptional()}\""
+            /*
+             * Only pick an optional dependency if it is already promoted. Because the plugin is likely to be installed
+             * in a client master in which case it is not "optional" anymore.
+             */
+            if(dep.getOptional()) {
+                println updateCenter.getPlugin(dep.name)?.versions
+                if(updateCenter.getPlugin(dep.name)?.versions == null) {
+                    println "${indent}  [DISCARD] optional and not in store"
+                    return
+                } else if(updateCenter.getPlugin(dep.name).getPromotedVersion() == null) {
+                    println "${indent}  [DISCARD] optional and not promoted"
+                    return
+                }
+            }
+            // Only check for a dependency if the requirement is higher than what we already found
+            VersionNumber currentVersionNumber = requiredDeps.get(dep.name)?.versionNumber
+            if (currentVersionNumber == null || currentVersionNumber.isOlderThan(new VersionNumber(dep.version))) {
+                consistent = fillRequiredDependencies(updateCenter, dep.name, dep.version, pickStrategy, checkedDeps,
+                        requiredDeps, "${indent} ")
+            } else {
+                println "${indent}  [DISCARD] (Already found a requirement for higher version: ${currentVersionNumber})"
+            }
+        }
+        requiredDeps.put(pluginData.name, pluginEntry)
+    } else {
+        println "${indent} [ERROR] No suitable version(s) found in store / or for download"
+        consistent = false
+    }
+    return consistent
+}
+
+/**
+ * Return a suitable stored version of a plugin (one equal or more recent).
+ * @param updateCenter The update center item
+ * @param name the name of the plugin
+ * @param version the version of the plugin
+ * @param pickStrategy strategy to apply when exact version is not available
+ * @param indent indent for log output
+ * @return The corresponding entry
+ */
+PluginEntry getSuitableVersionInStore(
+        UpdateCenter updateCenter,
+        String name,
+        String version,
+        String pickStrategy,
         String indent) {
 
     PluginData pluginData = updateCenter.getPlugin(name)
     VersionNumber pluginVersionNumber = new VersionNumber(version)
 
     /* Retrieve the plugin entry */
-    PluginEntry pluginEntry = pluginData.getVersions().find { entry -> entry.getKey() == pluginVersionNumber}?.getValue()
+    PluginEntry pluginEntry = pluginData.versions.find { entry -> entry.key == pluginVersionNumber}?.value
 
-    if(pluginEntry == null) {
-        println "${indent} Plugin ${pluginData.getName()}:${pluginVersionNumber} not pulled yet. Checking on store and updates."
-        pluginEntry = getSuitableVersion(updateCenter, name, version,"${indent} ")
-    }
+    if (pluginEntry == null || pickStrategy == "LATEST_STRICT") {
+        //Check for more recent versions
+        List<PluginEntry> moreRecentVersions = pluginData.versions.findAll {
+            entry -> entry.key >= pluginVersionNumber
+        }.collect {
+            entry -> entry.value
+        }
 
-    if(pluginEntry != null) {
-        requiredDeps.put(pluginData.getName(), pluginEntry)
-        /* Retrieve required dependencies */
-        pluginEntry.dependencies.findAll{ !it.getOptional() }?.each { dep ->
-            if(!checkedDeps.contains(dep)) {
-                println "${indent} [PULL] Checking dependency: \"name\": \"${dep.getName()}\", \"version\": \"${dep.getVersion()}\", \"optional\": \"${dep.getOptional()}\""
-                checkedDeps.add(dep)
-
-                VersionNumber currentVersionNumber = requiredDeps.get(dep.getName())?.getVersionNumber()
-                if(currentVersionNumber == null || currentVersionNumber.isOlderThan(new VersionNumber(dep.getVersion()))) {
-                    fillRequiredDependencies(updateCenter, dep.getName(), dep.getVersion(), checkedDeps, requiredDeps,"${indent} ")
-                } else {
-                    println "${indent}  Already found a requirement for higher version: ${currentVersionNumber} "
-                }
+        if (moreRecentVersions == null || moreRecentVersions.isEmpty()) {
+            println "${indent}Does not have any suitable version in store"
+        } else {
+            print "${indent}Requested version ${pluginVersionNumber} not available in store. Found more recent versions though."
+            if (pickStrategy == "CLOSEST") {
+                println " Using the closest version ${moreRecentVersions.get(moreRecentVersions.size() - 1).version}"
+                pluginEntry = moreRecentVersions.get(moreRecentVersions.size() - 1)
+            } else {
+                //Take the latest by default
+                println " Using the latest version ${moreRecentVersions.get(0).version}"
+                pluginEntry = moreRecentVersions.get(0)
             }
         }
+    } else {
+        println "${indent}Requested version ${pluginEntry.version} available in store"
     }
+    return pluginEntry
 }
 
 /**
- * Return a suitable version/update of a plugin (one equal or more recent). It will pick the most recent one if no exact match found.
+ * Return a suitable download version of a plugin (one equal or more recent).
  * @param updateCenter The update center item
  * @param name the name of the plugin
  * @param version the version of the plugin
+ * @param pickStrategy strategy to apply when exact version is not available
  * @param indent indent for log output
  * @return The corresponding entry
  */
-PluginEntry getSuitableVersion(UpdateCenter updateCenter, String name, String version, String indent) {
+PluginEntry getSuitableVersionToDownload(
+        UpdateCenter updateCenter,
+        String name,
+        String version,
+        String pickStrategy,
+        String indent) {
 
     PluginData pluginData = updateCenter.getPlugin(name)
     VersionNumber pluginVersionNumber = new VersionNumber(version)
 
-    /* Retrieve the plugin entry */
-    PluginEntry pluginEntry = pluginData.getVersions().find { entry -> entry.getKey() == pluginVersionNumber}?.getValue()
+    List<PluginEntry> pluginUpdates  = pluginData.updates.findAll {
+        entry -> entry.key >= pluginVersionNumber
+    }.collect {
+        entry -> entry.value
+    }
 
-    if(pluginEntry != null) {
-        //Found exact match
-        return pluginEntry
+    if (pluginUpdates == null || pluginUpdates.isEmpty()) {
+        println "${indent}[ERROR] Plugin ${pluginData.name} does not have any suitable updates available for download"
     } else {
-        //Check for more recent versions
-        List<PluginEntry> moreRecentVersions = pluginData.getVersions().findAll {
-            entry -> entry.getKey() >= pluginVersionNumber
-        }.collect {
-            entry -> entry.getValue()
-        }
-
-        if (moreRecentVersions == null || moreRecentVersions.isEmpty()) {
-            println "${indent} Plugin ${pluginData.getName()} does not have any suitable version stored"
-        } else {
-            println "${indent} Requested version not available in store but more recent versions found. Using the latest version ${moreRecentVersions.get(0).getVersion()}."
-            return moreRecentVersions.get(0)
-        }
-
-        // Need to pull, check for updates
-        List<PluginEntry> pluginUpdates  = pluginData.getUpdates().findAll {
-            entry -> entry.getKey() >= pluginVersionNumber
-        }.collect {
-            entry -> entry.getValue()
-        }
-
-        if (pluginUpdates == null || pluginUpdates.isEmpty()) {
-            println "${indent} [ERROR] Plugin ${pluginData.getName()} does not have any suitable updates available for download"
-        } else {
-            PluginEntry toDownload = pluginUpdates.find { it.getVersionNumber() == pluginVersionNumber}
-            if (toDownload == null) {
-                println "${indent} [WARNING] Requested version ${pluginVersionNumber} not available for download but more recent versions found. Using the latest version"
+        PluginEntry toDownload = pluginUpdates.find { it.versionNumber == pluginVersionNumber}
+        if (toDownload == null) {
+            print "${indent}Requested version ${pluginVersionNumber} not available for download. Found more recent versions though."
+            if(pickStrategy == "CLOSEST") {
+                println " Using the closest version ${pluginUpdates.get(pluginUpdates.size()-1).version}"
+                toDownload = pluginUpdates.get(pluginUpdates.size()-1)
+            } else {
+                //Take the latest by default
+                println " Using the latest version ${pluginUpdates.get(0).version}"
                 toDownload = pluginUpdates.get(0)
             }
-            println "${indent} [INFO] Requested version ${toDownload.getVersion()} available for download"
-            return toDownload
+        } else {
+            println "${indent}Requested version ${toDownload.version} available for download"
         }
-        return null
+        return toDownload
     }
+    return null
 }
-
-UpdateCenter myUC = jenkins.model.Jenkins.instance.getItemByFullName(updateCenterFullName, UpdateCenter.class)
-if(myUC == null) {
-    println "Cannot find UC '${updateCenterFullName}'!"
-}
-
-println "##########\nCalculate required dependencies:\n##########"
-// Construct the dependencies map
-Map<String, PluginEntry> requiredDeps = new HashMap<>()
-fillRequiredDependencies(myUC, pluginName, pluginVersion, new HashSet<DependencyEntry>(), requiredDeps, "")
 
 /*************************************************************
  * Store With Dependencies: Based on the list calculated above
@@ -153,20 +194,20 @@ fillRequiredDependencies(myUC, pluginName, pluginVersion, new HashSet<Dependency
  * @param pluginEntries the list of plugin entries to download
  * @return
  */
-def downloadPlugins(UpdateCenter updateCenter, Collection<PluginEntry> pluginEntries) {
+def downloadPlugins(UpdateCenter updateCenter, Collection<PluginEntry> pluginEntries, boolean dryRun) {
     pluginEntries.each { pluginEntry ->
-        PluginData pluginData = updateCenter.getPlugin(pluginEntry.getName())
-        if(pluginData.getVersions().find { entry -> entry.getKey() == pluginEntry.getVersionNumber()} != null) {
-            println " Plugin ${pluginEntry.getName()}:${pluginEntry.getVersionNumber()} is already pulled."
+        println "[${pluginEntry.name}:${pluginEntry.versionNumber}]"
+        PluginData pluginData = updateCenter.getPlugin(pluginEntry.name)
+        if(pluginData.versions.find { entry -> entry.key == pluginEntry.versionNumber} != null) {
+            println " Is already in store."
         } else {
-            println " Pulling plugin version ${pluginEntry.getName()}:${pluginEntry.getVersionNumber()}"
-            updateCenter.downloadPlugin(pluginEntry.getUrl(), pluginEntry.getName(), pluginEntry.getVersion(), pluginEntry.getSha1())
+            println " Pulling plugin version"
+            if(!dryRun) {
+                updateCenter.downloadPlugin(pluginEntry.getUrl(), pluginEntry.name, pluginEntry.version, pluginEntry.sha1)
+            }
         }
     }
 }
-
-println "##########\nDownload required dependencies:\n##########"
-downloadPlugins(myUC, requiredDeps.values())
 
 /***************************************************************
  * Promote With Dependencies: Based on the list calculated above
@@ -178,23 +219,106 @@ downloadPlugins(myUC, requiredDeps.values())
  * @param pluginEntries the list of plugin entries to promote
  * @return
  */
-def promotePlugins(UpdateCenter updateCenter, Collection<PluginEntry> pluginEntries) {
+def promotePlugins(UpdateCenter updateCenter, Collection<PluginEntry> pluginEntries, boolean dryRun) {
     pluginEntries.each { pluginEntry ->
-        PluginData pluginData = updateCenter.getPlugin(pluginEntry.getName())
-        if(pluginData.getVersions().find { entry -> entry.getKey() == pluginEntry.getVersionNumber()} != null) {
-            if (pluginData.getPromotedVersionNumber() != pluginEntry.getVersionNumber()) {
-                println " Promoting plugin version ${pluginEntry.getName()}:${pluginEntry.getVersionNumber()}"
-                pluginData.setPromotedVersion(pluginEntry.getVersion())
+        println "[${pluginEntry.name}:${pluginEntry.versionNumber}]"
+        PluginData pluginData = updateCenter.getPlugin(pluginEntry.name)
+        if(pluginData.versions.find { entry -> entry.key == pluginEntry.versionNumber} != null) {
+            if (pluginData.promotedVersionNumber != pluginEntry.versionNumber) {
+                println " Promoting plugin version"
+                if(!dryRun) {
+                    pluginData.setPromotedVersion(pluginEntry.version)
+                }
             } else {
-                println " ${pluginEntry.getName()}:${pluginEntry.getVersionNumber()} is already promoted."
+                println " Is already promoted."
             }
         } else {
-            println " Plugin ${pluginEntry.getName()}:${pluginEntry.getVersionNumber()} is not pulled yet."
+            println " Is not in store."
         }
     }
 }
 
-println "##########\nPromote required dependencies:\n##########"
-promotePlugins(myUC, requiredDeps.values())
+/*************************************************
+ * Variables:
+ * Change the following variable to suit your need.
+ * Default configuration provide detailed output
+ * and do not apply any changes
+ *************************************************/
 
+/**
+ * The plugin name.
+ * Example: 'cloudbees-template'
+ */
+String pluginName = "${pluginName}"
+/**
+ * The plugin version. Note that if the EXACT version cannot be found in store or for download, the latest
+ * available version will be picked by the script.
+ * This can be controlled with ${updateCenterStrategy} but ONLY higher versions are considered suitable.
+ * Example: '4.28'
+ */
+String pluginVersion = "${pluginVersion}"
+/**
+ * Full Name of the custom update center.
+ * Example: 'myFolder/myUc'
+ */
+String updateCenterFullName = "${updateCenterFullName}"
+/**
+ * Action to undertake after calculating the dependencies.
+ *
+ * - 'STORE': Download/Store the plugin with its Dependencies
+ * - 'PROMOTE': Promote the plugin with its Dependencies
+ * - 'NOOP' or empty|null: do nothing
+ */
+String updateCenterAction = "STORE"
+/**
+ * Control whether to apply the updateCenterAction of just execute a test run:
+ */
+boolean updateCenterActionDryRun = true
+/**
+ * Strategy for picking available version when an exact match is not found. When checking version available in store
+ * or for download, the script picks the exact version if it can find it, otherwise the default behavior is to pick
+ * the latest version available. This can be controlled with this variable:
+ *
+ * - 'LATEST_STRICT': pick the latest version available for download EVEN IF AN EXACT MATCH IS FOUND
+ * - 'LATEST' or empty|null: pick the latest version found (example: checking for 1.2, found 1.3 and 1.5 -> pick 1.5)
+ * - 'CLOSEST': pick the closest higher version found (example: checking for 1.2, found 1.3 and 1.5 -> pick 1.3)
+ */
+String updateCenterStrategy = "LATEST_STRICT"
+
+/*************************************************
+ * Execution
+ *************************************************/
+
+UpdateCenter myUC = jenkins.model.Jenkins.instance.getItemByFullName(updateCenterFullName, UpdateCenter.class)
+if(myUC == null) {
+    println "Cannot find UC '${updateCenterFullName}'!"
+}
+
+println "\nCalculate required dependencies:\n----------------------------------"
+// Construct the dependencies map
+Map<String, PluginEntry> requiredDeps = new HashMap<>()
+boolean isConsistent = fillRequiredDependencies(
+        myUC,
+        pluginName,
+        pluginVersion,
+        updateCenterStrategy,
+        new HashSet<DependencyEntry>(),
+        requiredDeps, "")
+
+println "\nResult\n----------------------------------"
+requiredDeps.values().each {
+    println "${it.getName()}:${it.getVersionNumber()}"
+}
+
+if(!isConsistent) {
+    println "\n[ERROR]: Found inconsistencies during the calculation of dependencies. Have a look at '[ERROR]' messages."
+}
+
+if(updateCenterAction == "STORE") {
+    println "\nDownload required dependencies:\n----------------------------------"
+    downloadPlugins(myUC, requiredDeps.values(), updateCenterActionDryRun)
+} else if (updateCenterAction == "PROMOTE") {
+    println "\nPromote required dependencies:\n----------------------------------"
+    promotePlugins(myUC, requiredDeps.values(), updateCenterActionDryRun)
+}
 return

--- a/ucStoreAndPromoteWithDependencies.groovy
+++ b/ucStoreAndPromoteWithDependencies.groovy
@@ -46,7 +46,7 @@ String updateCenterFullName = "${updateCenterFullName}"
  * - 'PROMOTE': Promote the plugin with its Dependencies
  * - 'NOOP' or empty|null: do nothing
  */
-String updateCenterAction = "STORE"
+String updateCenterAction = "NOOP"
 /**
  * Control whether to apply the updateCenterAction of just execute a test run:
  *
@@ -69,8 +69,6 @@ boolean updateCenterActionDryRun = true
  *
  * - 'LATEST': pick the latest version available in store EVEN IF AN EXACT MATCH IS FOUND
  * - 'DEFAULT' or empty|null: if NO EXACT MATCH found for download, pick the latest version found in store (example: checking for 1.2, found 1.3 and 1.5 -> pick 1.5)
- * - 'CLOSEST': pick the closest higher version found (example: checking for 1.2, found 1.3 and 1.5 -> pick 1.3)
- * - 'PARANOID': pick the exact version found but no others
  *
  * Note: With either LATEST / DEFAULT, the output shows all the required dependencies
  */
@@ -80,10 +78,8 @@ String updateCenterStoreStrategy = "LATEST"
  * version if it can find it, otherwise the default behavior is to pick the latest version available. This can be
  * controlled with this variable:
  *
- * - 'LATEST': pick the latest version available in store EVEN IF AN EXACT MATCH IS FOUND
+ * - 'LATEST': pick the latest version available for download EVEN IF AN EXACT MATCH IS FOUND
  * - 'DEFAULT' or empty|null: if NO EXACT MATCH found for download, pick the latest version found for download (example: checking for 1.2, found 1.3 and 1.5 -> pick 1.5)
- * - 'CLOSEST': pick the closest higher version found (example: checking for 1.2, found 1.3 and 1.5 -> pick 1.3)
- * - 'PARANOID': pick the exact version found but no others
  *
  * Note: With either LATEST / DEFAULT, the output shows all the required dependencies
  */
@@ -213,16 +209,11 @@ PluginEntry getSuitableVersionInStore(
     } else {
         toStore = pluginVersionsStored.find { it.versionNumber == pluginVersionNumber}
         println "${indent}Requested version ${pluginVersionNumber} ${toStore != null ? "" : "not "}available in store"
-        if ((toStore == null && storeStrategy != "PARANOID") || storeStrategy == "LATEST") {
+        if (toStore == null || storeStrategy == "LATEST") {
             print "${indent}Found suitable versions in store:"
-            if (storeStrategy == "CLOSEST") {
-                println " using the closest version ${pluginVersionsStored.get(pluginVersionsStored.size() - 1).version}"
-                toStore = pluginVersionsStored.get(pluginVersionsStored.size() - 1)
-            } else {
-                //Take the latest by default
-                println " using the latest version ${pluginVersionsStored.get(0).version}"
-                toStore = pluginVersionsStored.get(0)
-            }
+            //Take the latest by default
+            println " using the latest version ${pluginVersionsStored.get(0).version}"
+            toStore = pluginVersionsStored.get(0)
         }
     }
     return toStore
@@ -255,16 +246,11 @@ PluginEntry getSuitableVersionToDownload(
     } else {
         toDownload = pluginUpdates.find { it.versionNumber == pluginVersionNumber}
         println "${indent}Requested version ${pluginVersionNumber} ${toDownload != null ? "" : "not"} available for download"
-        if ((toDownload == null && downloadStrategy != "PARANOID")|| downloadStrategy == "LATEST") {
+        if (toDownload == null || downloadStrategy == "LATEST") {
             print "${indent}Found suitable versions for download:"
-            if(downloadStrategy == "CLOSEST") {
-                println " Using the closest version ${pluginUpdates.get(pluginUpdates.size()-1).version}"
-                toDownload = pluginUpdates.get(pluginUpdates.size()-1)
-            } else {
-                //Take the latest by default
-                println " Using the latest version ${pluginUpdates.get(0).version}"
-                toDownload = pluginUpdates.get(0)
-            }
+            //Take the latest by default
+            println " Using the latest version ${pluginUpdates.get(0).version}"
+            toDownload = pluginUpdates.get(0)
         }
     }
     return toDownload


### PR DESCRIPTION
@cloudbees/team-support @duemir 

A script to calculate dependencies of a plugin in a Custom Update Center. It fills a collection of required dependencies. 

The collection can be used to either automatically store a plugin and its dependencies OR promote a plugin and its dependencies.

But doing both is not a good idea. The download tasks are actually Queue.Tasks that are scheduled immediately. So **we would have to wait for all download tasks to finish before launching the promote**...

Maybe we can add a field to decide whether we want to STORE or PROMOTE:

```
if(action == "STORE") {
    downloadPlugins(myUC, requiredDeps.values())
} else if (action == "PROMOTE") {
    promotePlugins(myUC, requiredDeps.values())
}
```

Or really code something that wait for the completion of download tasks to launch the promote. Something like:

```
Queue.Item pluginQueueItem = jenkins.model.Jenkins.getActiveInstance().getQueue().getItems().find { item ->
    item.task instanceof DownloadPluginTask && ((DownloadPluginTask)item.task).plugin == pluginName && ((DownloadPluginTask)item.task).version == pluginVersion
}

if(pluginQueueItem != null && jenkins.model.Jenkins.getActiveInstance().getQueue().getItem(pluginQueueItem.getId()) != null) {
    print "Waiting for DownloadPluginTask '${pluginQueueItem}' to complete."
    while (jenkins.model.Jenkins.getActiveInstance().getQueue().getItem(pluginQueueItem.getId()) != null) {
        sleep(1000)
        print "."
    }
}
```