### PR TITLE
Fix missing  import

### DIFF
--- a/get-lastlogin-users.groovy
+++ b/get-lastlogin-users.groovy
@@ -3,6 +3,7 @@
 list all real users and shows the lastLogin datetime, those that have LastGrantedAuthoritiesProperty because them logen one time.
 **/
 import org.acegisecurity.*
+import hudson.model.User
 import jenkins.security.*
 import java.util.Date
 


### PR DESCRIPTION
Without this import `import hudson.model.User`, we have an exception on `User.getAll()`