### PR TITLE
Fix argument for setInterval function

### DIFF
--- a/setOrgFolderIndex.groovy
+++ b/setOrgFolderIndex.groovy
@@ -21,7 +21,7 @@ return
 //This function is not called above
 //Acceptable values for triggers can be found here: 
 //https://github.com/jenkinsci/cloudbees-folder-plugin/blob/master/src/main/java/com/cloudbees/hudson/plugins/folder/computed/PeriodicFolderTrigger.java#L241
-def setInterval(interval) {
+def setInterval(folder) {
   println "[INFO] : Updating ${folder.name}... " 
   folder.getTriggers().find {triggerEntry ->
     def key = triggerEntry.key


### PR DESCRIPTION
Fix the argument for the `setInterval` function in the `setOrgFolderIndex` script. This should be `folder` and not `interval`. The interval is already provided inside of the function.