### PR TITLE
List masters that need upgrading

### DIFF
--- a/license-upgrade/apply-license.groovy
+++ b/license-upgrade/apply-license.groovy
@@ -252,7 +252,7 @@ if ((manager != null) && (manager.getParsed().isWildcard())) {
                   println "No new license available.  Contact csm-help@cloudbees.com to obtain a license."
               }
           } else {
-              println "One or more masters have an incompatible version of cloudbees-license plugin. Please update them:"
+              println "One or more masters have an incompatible version of cloudbees-license plugin. Please update them before applying the new license:"
               map.findAll { k,v -> v[1][0] != "1"}.keySet().each { name ->
                   println " * ${name}"
               }

--- a/license-upgrade/apply-license.groovy
+++ b/license-upgrade/apply-license.groovy
@@ -252,7 +252,10 @@ if ((manager != null) && (manager.getParsed().isWildcard())) {
                   println "No new license available.  Contact csm-help@cloudbees.com to obtain a license."
               }
           } else {
-              println "One or more masters have an incompatible version of cloudbees-license plugin. Please update them."
+              println "One or more masters have an incompatible version of cloudbees-license plugin. Please update them:"
+              map.findAll { k,v -> v[1][0] != "1"}.keySet().each { name ->
+                  println " * ${name}"
+              }
           }
       } else {
           println "cloudbees-license plugin installed on operations center is not compatible with new license. Please update it."


### PR DESCRIPTION
In CJOC environment, list masters that need upgrading when incompatible masters have been found. Example output:

```
apply-license.groovy running...
Checks the license server for the new license, and if available, installs the license.
Determine the instance type: Operations Center
One or more masters have an incompatible version of cloudbees-license plugin. Please update them:
 * old-mm-2
```