### PR TITLE
Add special support for CJE v2.46.2.1

### DIFF
--- a/license-upgrade/apply-license.groovy
+++ b/license-upgrade/apply-license.groovy
@@ -186,10 +186,24 @@ println "Checks the license server for the new license, and if available, instal
 
 def type = productType()
 
-println "Determine the instance type: " + type
+def _stopFlag = false
+def assurance = com.cloudbees.jenkins.plugins.assurance.CloudBeesAssurance.get()
+def _summary = new StringBuilder()
+
+println "Determine the instance type: " + type + " v" + jenkins.model.Jenkins.instance.getVersion().toString()
 def manager = hudson.license.LicenseManager.getInstanceOrDie()
 if ((manager != null) && (manager.getParsed().isWildcard())) {
   println type.toString() + " currently has a wildcard license installed.  Contact csm-help@cloudbees.com to obtain a license."
+} else if (!assurance.metaClass.respondsTo(assurance,"getOfferedEnvelope").isEmpty()) {
+  if (jenkins.model.Jenkins.instance.getVersion().toString().contains("2.46.2.1")) {
+    _stopFlag = true
+    if (type == Product.OPERATIONS_CENTER) {
+        _summary.append("The updated license must be installed manually on Cloudbees Jenkins Operations Center v.2.46.2.1\n")
+    } else {
+        _summary.append("The updated license must be installed manually on Cloudbees Jenkins v.2.46.2.1\n")
+    }
+    _summary.append("Contact csm-help@cloudbees.com for assistance")
+  }
 } else {
   if (type == Product.OPERATIONS_CENTER) {
       // update operations center license

--- a/license-upgrade/upgrade-license-plugin.groovy
+++ b/license-upgrade/upgrade-license-plugin.groovy
@@ -263,7 +263,7 @@ if (!assurance.metaClass.respondsTo(assurance,"getOfferedEnvelope").isEmpty()) {
   }
 }
 
-println "Determine the instance type: " + type
+println "Determine the instance type: " + type + " v" + jenkins.model.Jenkins.instance.getVersion().toString()
 boolean all = true
 if ((type == Product.OPERATIONS_CENTER) && (!_stopFlag)) {
     int plugins = 0

--- a/license-upgrade/verify-system-readiness.groovy
+++ b/license-upgrade/verify-system-readiness.groovy
@@ -166,15 +166,28 @@ _statusKey[15] = "Product Version"
 _statusKey[16] = "Using wildcard license?"
 
 def _summary = new StringBuilder()
+def _summary2 = new StringBuilder()
 
 def _status = executeScriptInLocally(script)
-
+def _stopFlag = false
+def assurance = com.cloudbees.jenkins.plugins.assurance.CloudBeesAssurance.get()
 def manager = hudson.license.LicenseManager.getInstanceOrDie()
+
 if (manager == null) {
   _status[16] = "?"
 } else if (manager.getParsed().isWildcard()) {
   _status[16] = "1"
   _summary.append("Your instance is using a wildcard license. Contact csm-help@cloudbees.com to obtain a license.\n\n")
+} else if (!assurance.metaClass.respondsTo(assurance,"getOfferedEnvelope").isEmpty()) {
+  if (jenkins.model.Jenkins.instance.getVersion().toString().contains("2.46.2.1")) {
+    _stopFlag = true
+    if (productType() == Product.OPERATIONS_CENTER) {
+        _summary2.append("Cloudbees Jenkins Operations Center v.2.46.2.1 and any client masters must be updated manually via Beekeeper.\n")
+    } else {
+        _summary2.append("Cloudbees Jenkins v.2.46.2.1 must be updated manually via Beekeeper.\n")
+    }
+    _summary2.append("Contact csm-help@cloudbees.com for assistance")
+  }
 } else {
   _status[16] = "0"
 }
@@ -193,7 +206,7 @@ if (debug) {
   }
 }
 
-if (productType() == Product.OPERATIONS_CENTER) {
+if ((productType() == Product.OPERATIONS_CENTER) && (!_stopFlag)) {
   int plugins = 0
   int licenses = 0
   int offline = 0
@@ -258,6 +271,7 @@ if (productType() == Product.OPERATIONS_CENTER) {
   println _summary.toString()
 }
 
+println _summary2.toString()
 
 // script-status common code
 // ------------------------------------------------------------------------------------------------

--- a/license-upgrade/verify-system-readiness.groovy
+++ b/license-upgrade/verify-system-readiness.groovy
@@ -271,7 +271,9 @@ if ((productType() == Product.OPERATIONS_CENTER) && (!_stopFlag)) {
   println _summary.toString()
 }
 
-println _summary2.toString()
+if (_status[4] != "1" || _status[13] != "1" && !_stopFlag) {
+  println _summary2.toString()
+}
 
 // script-status common code
 // ------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Product version 2.46.2.1 includes a misaligned version of the `cloudbees-assurance` plugin, which causes a number of API breakages for the license upgrade scripts.  Given the risk of introducing new issues for all other currently supported product versions, this PR adds some minimal checks and user messaging which instructs the (very few) customers on this verison that they cannot update by using the scripts, and should instead contact csm-help@cloudbees.com.

output examples for users who on v2.46.2.1:

**verify-system-readiness.groovy**
```
verify-system-readiness.groovy running...
Determining the instance type...Operations Center
Operations Center v2.46.2.1 - cloudbees-license plugin 9.9.1 is installed. This instance is ready to install the new license.

Operations Center v2.46.2.1 must have its license manually updated.
Contact csm-help@cloudbees.com for assistance
```

**update-license-plugin.groovy**
```
upgrade-license-plugin.groovy running...
Determine the instance type: Operations Center v2.46.2.1

------------------------------------------- SUMMARY -----------------------------------------

You have one or more instances that need to be upgraded.

Cloudbees Jenkins Operations Center v.2.46.2.1 and any client masters must be updated manually via Beekeeper.
Contact csm-help@cloudbees.com for assistance
```

**apply-license.groovy**
```
apply-license.groovy running...
Checks the license server for the new license, and if available, installs the license.
Determine the instance type: Operations Center v2.46.2.1
Result: The updated license must be installed manually on Cloudbees Jenkins Operations Center v.2.46.2.1
Contact csm-help@cloudbees.com for assistance
```