### PR TITLE
[CE-4779] Fix example for KubernetesImagePullSecret

### DIFF
--- a/createManagedMasterK8s.groovy
+++ b/createManagedMasterK8s.groovy
@@ -47,7 +47,10 @@ String  k8sEnvVars = ""
 String  k8sJavaOptions = ""
 String  k8sJenkinsOptions = ""
 String  k8sImage = 'CloudBees Core - Managed Master - 2.176.4.3'
-List<KubernetesImagePullSecret> k8sImagePullSecrets = Collections.emptyList() // Example: Arrays.asList(new KubernetesImagePullSecret("useast-ecr-reg"))
+List<KubernetesImagePullSecret> k8sImagePullSecrets = Collections.emptyList()
+// Example: 
+//   def k8sImagePullSecret1 = new KubernetesImagePullSecret(); k8sImagePullSecret1.setValue("useast-reg")
+//   List<KubernetesImagePullSecret> k8sImagePullSecrets = Arrays.asList(k8sImagePullSecret1)
 Integer k8sLivenessInitialDelaySeconds = 300
 Integer k8sLivenessPeriodSeconds = 10
 Integer k8sLivenessTimeoutSeconds = 10

--- a/createTeamMasterK8s.groovy
+++ b/createTeamMasterK8s.groovy
@@ -67,7 +67,10 @@ String  k8sEnvVars = ""
 String  k8sJavaOptions = ""
 String  k8sJenkinsOptions = ""
 String  k8sImage = 'CloudBees Core - Managed Master - 2.176.4.3'
-List<KubernetesImagePullSecret> k8sImagePullSecrets = Collections.emptyList() // Example: Arrays.asList(new KubernetesImagePullSecret("useast-ecr-reg"))
+List<KubernetesImagePullSecret> k8sImagePullSecrets = Collections.emptyList()
+// Example: 
+//   def k8sImagePullSecret1 = new KubernetesImagePullSecret(); k8sImagePullSecret1.setValue("useast-reg")
+//   List<KubernetesImagePullSecret> k8sImagePullSecrets = Arrays.asList(k8sImagePullSecret1)
 Integer k8sLivenessInitialDelaySeconds = 300
 Integer k8sLivenessPeriodSeconds = 10
 Integer k8sLivenessTimeoutSeconds = 10


### PR DESCRIPTION
[CE-4779](https://cloudbees.atlassian.net/browse/CE-4779): The KubernetesImagePullSecret only has a [default constructor](https://github.com/cloudbees/cloud-platform-master-provisioning-plugin/blob/master-provisioning-parent-2.5.2/master-provisioning-kubernetes/src/main/java/com/cloudbees/masterprovisioning/kubernetes/KubernetesImagePullSecret.java#L33-L35)