### PR TITLE
[CE-5455] Credentials migration scripts

### DIFF
--- a/credentials-migration/README.md
+++ b/credentials-migration/README.md
@@ -25,3 +25,5 @@ The encoded message will be used later on to update the credentials in the new J
 3. Download the `update-credentials-folder-level.groovy` on [GitHub](https://github.com/cloudbees/jenkins-scripts/tree/master/credentials-migration/update-credentials-folder-level.groovy).
 
 Paste the encoded message output from the `export-credentials-folder-level.groovy` script as the value in the encoded variable in the `update-credentials-folder-level.groovy` script and execute it in the Script Console on the destination Jenkins. All the folder credentials from the source Jenkins will now be updated to each folder store of the destination Jenkins.
+
+These scripts were created taking as an example [cloudbees-ci/cje-to-ci-migration-examples](https://github.com/cloudbees/cloudbees-examples/tree/master/cloudbees-ci/cje-to-ci-migration-examples/CredentialsMigration)

--- a/credentials-migration/README.md
+++ b/credentials-migration/README.md
@@ -1,0 +1,27 @@
+# Jenkins Credentials Migration
+
+The following scripts are created to migrate the credentials at Root (System) and Folder level from one Jenkins Master to another one.
+
+In Jenkins, `$JENKINS_HOME/secrets/master.key` is the secret used to encrypt all the credentials stored on disk. The new instances created will have their own `$JENKINS_HOME/secrets/master.key`, so it is necessary to export/import the credentials to re-encrypt them in the new Jenkins master.
+
+## Migrate the System credentials
+
+1. Download the `export-credentials-system-level.groovy` script on [GitHub](https://github.com/cloudbees/jenkins-scripts/tree/master/credentials-migration/export-credentials-system-level.groovy).
+2. Run `export-credentials-system-level.groovy` in the Script Console on the source instance. It will output an encoded message containing a flattened list of all system credentials. Copy that encoded message.
+
+The encoded message will be used later on to export the credentials in the new Jenkins Master.
+
+3. Download the `update-credentials-system-level.groovy` on [GitHub](https://github.com/cloudbees/jenkins-scripts/tree/master/credentials-migration/update-credentials-system-level.groovy).
+
+Paste the encoded message output from the `export-credentials-system-level.groovy` script as the value in the encoded variable in the `update-credentials-system-level.groovy` script and execute it in the Script Console on the destination Jenkins. All the System credentials from the source Jenkins will now be updated to the system store of the destination Jenkins. 
+
+## Migrate the Folder credential
+
+1. Download the `export-credentials-folder-level.groovy` script on [GitHub](https://github.com/cloudbees/jenkins-scripts/tree/master/credentials-migration/export-credentials-folder-level.groovy).
+2. Run `export-credentials-folder-level.groovy` in the Script Console on the source instance. It will output an encoded message containing a flattened list of all system credentials. Copy that encoded message.
+
+The encoded message will be used later on to update the credentials in the new Jenkins Master.
+
+3. Download the `import-credentials-folder-level.groovy` on [GitHub](https://github.com/cloudbees/jenkins-scripts/tree/master/credentials-migration/update-credentials-folder-level.groovy).
+
+Paste the encoded message output from the `export-credentials-folder-level.groovy` script as the value in the encoded variable in the `update-credentials-folder-level.groovy` script and execute it in the Script Console on the destination Jenkins. All the System credentials from the source Jenkins will now be updated to the system store of the destination Jenkins.

--- a/credentials-migration/README.md
+++ b/credentials-migration/README.md
@@ -22,6 +22,6 @@ Paste the encoded message output from the `export-credentials-system-level.groov
 
 The encoded message will be used later on to update the credentials in the new Jenkins Master.
 
-3. Download the `import-credentials-folder-level.groovy` on [GitHub](https://github.com/cloudbees/jenkins-scripts/tree/master/credentials-migration/update-credentials-folder-level.groovy).
+3. Download the `update-credentials-folder-level.groovy` on [GitHub](https://github.com/cloudbees/jenkins-scripts/tree/master/credentials-migration/update-credentials-folder-level.groovy).
 
-Paste the encoded message output from the `export-credentials-folder-level.groovy` script as the value in the encoded variable in the `update-credentials-folder-level.groovy` script and execute it in the Script Console on the destination Jenkins. All the System credentials from the source Jenkins will now be updated to the system store of the destination Jenkins.
+Paste the encoded message output from the `export-credentials-folder-level.groovy` script as the value in the encoded variable in the `update-credentials-folder-level.groovy` script and execute it in the Script Console on the destination Jenkins. All the folder credentials from the source Jenkins will now be updated to each folder store of the destination Jenkins.

--- a/credentials-migration/export-credentials-folder-level.groovy
+++ b/credentials-migration/export-credentials-folder-level.groovy
@@ -1,0 +1,71 @@
+/*
+Author: Félix Belzunce Arcos
+Since: January 2021
+Description: Encode in Base64 all the credentials of a Jenkins Master at Folder level. The script is used to update all the credentials at folder level, so they can be re-encrypted in another Jenkins Master. 
+
+The script should be executed in the Script Console. It will output an encoded message containing a flattened list of all the folder credentials. Copy that encoded message.
+
+The encoded message can be used to update the credentials in a new Jenkins Master.
+*/
+
+import com.cloudbees.hudson.plugins.folder.Folder
+import com.cloudbees.hudson.plugins.folder.properties.FolderCredentialsProvider
+import com.cloudbees.plugins.credentials.domains.DomainCredentials
+import com.thoughtworks.xstream.converters.Converter
+import com.thoughtworks.xstream.converters.MarshallingContext
+import com.thoughtworks.xstream.converters.UnmarshallingContext
+import com.thoughtworks.xstream.io.HierarchicalStreamReader
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter
+import com.trilead.ssh2.crypto.Base64
+import hudson.util.Secret
+import hudson.util.XStream2
+import jenkins.model.Jenkins
+
+def instance = Jenkins.get()
+def credentials = []
+HashMap<String, List<DomainCredentials>> credentialsPerFolder = new HashMap<String, List<DomainCredentials>>();
+
+// Each folder contains a Store. A Store contains one or more Domains 
+// and each Domain might contain Credentials defined. 
+def folderExtension = instance.getExtensionList(FolderCredentialsProvider.class)
+if (!folderExtension.empty) {
+    def folders = instance.getAllItems(Folder.class)
+    def folderProvider = folderExtension.first()
+    def domainName
+    for (folder in folders) {
+        def store = folderProvider.getStore(folder)
+        println "Adding the folder Store " + store.getContext().getFullDisplayName()
+        def listDomainCredentials = new ArrayList<DomainCredentials>();
+        for (domain in store.domains) {
+            domainName = domain.isGlobal() ? "Global":domain.getName();
+            println "   Adding the Domain " + domainName
+            listDomainCredentials.add(new DomainCredentials(domain, store.getCredentials(domain)));
+        }
+        credentialsPerFolder.put(store.getContext().getFullDisplayName(), listDomainCredentials);
+    }
+}
+
+// The converter ensures that the output XML contains the unencrypted secrets
+def converter = new Converter() {
+    @Override
+    void marshal(Object object, HierarchicalStreamWriter writer, MarshallingContext context) {
+        writer.value = Secret.toString(object as Secret)
+    }
+
+    @Override
+    Object unmarshal(HierarchicalStreamReader reader, UnmarshallingContext context) { null }
+
+    @Override
+    boolean canConvert(Class type) { type == Secret.class }
+}
+
+def stream = new XStream2()
+stream.registerConverter(converter)
+
+// Marshal the list of credentials into XML
+def encoded = []
+
+    def xml = Base64.encode(stream.toXML(credentialsPerFolder).bytes)
+    encoded.add("\"${xml}\"")
+
+println encoded.toString()

--- a/credentials-migration/export-credentials-system-level.groovy
+++ b/credentials-migration/export-credentials-system-level.groovy
@@ -1,0 +1,63 @@
+/*
+Author: Félix Belzunce Arcos
+Since: January 2021
+Description: Encode in Base64 all the credentials of a Jenkins Master at System level. The script is used to update all the credentials at System level, re-encrypting them in another Jenkins Master. 
+
+The script should be executed in the Script Console. It will output an encoded message containing a flattened list of all the System credentials. Copy that encoded message.
+
+The encoded message can be used to update the System credentials in a new Jenkins Master. 
+*/
+
+import com.cloudbees.plugins.credentials.SystemCredentialsProvider
+import com.cloudbees.plugins.credentials.domains.DomainCredentials
+import com.thoughtworks.xstream.converters.Converter
+import com.thoughtworks.xstream.converters.MarshallingContext
+import com.thoughtworks.xstream.converters.UnmarshallingContext
+import com.thoughtworks.xstream.io.HierarchicalStreamReader
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter
+import com.trilead.ssh2.crypto.Base64
+import hudson.util.Secret
+import hudson.util.XStream2
+import jenkins.model.Jenkins
+
+def instance = Jenkins.get()
+def credentials = []
+
+// Copy all domains from the system credentials provider
+def systemProvider = instance.getExtensionList(SystemCredentialsProvider.class)
+if (!systemProvider.empty) {
+    def systemStore = systemProvider.first().getStore()
+    def domainName
+    for (domain in systemStore.domains) {
+        domainName = domain.isGlobal() ? "Global":domain.getName()
+        println "Adding credentials from System Domain: " + domainName
+        credentials.add(new DomainCredentials(domain, systemStore.getCredentials(domain)))
+    }
+}
+
+// The converter ensures that the output XML contains the unencrypted secrets
+def converter = new Converter() {
+    @Override
+    void marshal(Object object, HierarchicalStreamWriter writer, MarshallingContext context) {
+        writer.value = Secret.toString(object as Secret)
+    }
+
+    @Override
+    Object unmarshal(HierarchicalStreamReader reader, UnmarshallingContext context) { null }
+
+    @Override
+    boolean canConvert(Class type) { type == Secret.class }
+}
+
+def stream = new XStream2()
+stream.registerConverter(converter)
+
+// Marshal the list of credentials into XML
+def encoded = []
+def sections = credentials.collate(25)
+for (section in sections) {
+    def xml = Base64.encode(stream.toXML(section).bytes)
+    encoded.add("\"${xml}\"")
+}
+
+println encoded.toString()

--- a/credentials-migration/update-credentials-folder-level.groovy
+++ b/credentials-migration/update-credentials-folder-level.groovy
@@ -53,7 +53,7 @@ if (!folderExtension.empty) {
         println "Updating domain " + domainName
         for (credential in domain.credentials) {
             println "   Updating credential: " + credential.id;
-            println store.updateCredentials(domain.getDomain(), credential, credential)
+            store.updateCredentials(domain.getDomain(), credential, credential)
         }
       }
     }

--- a/credentials-migration/update-credentials-folder-level.groovy
+++ b/credentials-migration/update-credentials-folder-level.groovy
@@ -4,7 +4,7 @@ Since: January 2021
 Description: Decode from export-credentials-folder-level.groovy script, all the credentials of a Jenkins Master at Folder level. Paste the encoded message output from the export-credentials-folder-level.groovy script as the value in the encoded variable in this script and execute it in the Script Console on the destination Jenkins. All the credentials and domains at folder level from the source Jenkins will now be updated.
 */
 
-import com.cloudbees.hudson.plugins.folder.Folder
+import com.cloudbees.hudson.plugins.folder.AbstractFolder
 import com.cloudbees.hudson.plugins.folder.properties.FolderCredentialsProvider
 import com.cloudbees.plugins.credentials.domains.DomainCredentials
 import com.thoughtworks.xstream.converters.Converter
@@ -34,25 +34,26 @@ HashMap<String, List<DomainCredentials>> credentialsList;
 // The message is decoded and unmarshaled
 for (slice in encoded) {
     def decoded = new String(Base64.decode(slice.chars))
-    domainListByFolders = new XStream2().fromXML(decoded) as HashMap<String, List<DomainCredentials>>  ;  
+    domainsFromFolders = new XStream2().fromXML(decoded) as HashMap<String, List<DomainCredentials>>  ;  
 }
 
 def instance = Jenkins.get()
 def folderExtension = instance.getExtensionList(FolderCredentialsProvider.class)
 if (!folderExtension.empty) {
-  def folders = instance.getAllItems(Folder.class)
+  def folders = instance.getAllItems(AbstractFolder.class)
   def folderProvider = folderExtension.first()
   def store
   def domainName
   for (folder in folders) {
     store = folderProvider.getStore(folder)
-    folderDomains = domainListByFolders.get(store.getContext().getFullDisplayName())
+    println "Procesing Store for " + store.getContext().getUrl()
+    folderDomains = domainsFromFolders.get(store.getContext().getUrl())
     if (folderDomains!=null) {
       for (domain in folderDomains) {
         domainName = domain.getDomain().isGlobal() ? "Global":domain.getDomain().getName()
-        println "Updating domain " + domainName
+        println "   Updating domain " + domainName
         for (credential in domain.credentials) {
-            println "   Updating credential: " + credential.id;
+            println "     Updating credential: " + credential.id;
             store.updateCredentials(domain.getDomain(), credential, credential)
         }
       }

--- a/credentials-migration/update-credentials-folder-level.groovy
+++ b/credentials-migration/update-credentials-folder-level.groovy
@@ -1,0 +1,61 @@
+/*
+Author: Félix Belzunce Arcos
+Since: January 2021
+Description: Decode from export-credentials-folder-level.groovy script, all the credentials of a Jenkins Master at Folder level. Paste the encoded message output from the export-credentials-folder-level.groovy script as the value in the encoded variable in this script and execute it in the Script Console on the destination Jenkins. All the credentials and domains at folder level from the source Jenkins will now be updated.
+*/
+
+import com.cloudbees.hudson.plugins.folder.Folder
+import com.cloudbees.hudson.plugins.folder.properties.FolderCredentialsProvider
+import com.cloudbees.plugins.credentials.domains.DomainCredentials
+import com.thoughtworks.xstream.converters.Converter
+import com.thoughtworks.xstream.converters.MarshallingContext
+import com.thoughtworks.xstream.converters.UnmarshallingContext
+import com.thoughtworks.xstream.io.HierarchicalStreamReader
+import com.thoughtworks.xstream.io.HierarchicalStreamWriter
+import com.trilead.ssh2.crypto.Base64
+import hudson.util.Secret
+import hudson.util.XStream2
+import jenkins.model.Jenkins
+import com.cloudbees.plugins.credentials.domains.DomainCredentials
+import com.trilead.ssh2.crypto.Base64
+import hudson.util.XStream2
+import jenkins.model.Jenkins
+import com.cloudbees.plugins.credentials.Credentials
+
+// Paste the encoded message from the script on the source Jenkins
+def encoded=[]
+
+if (!encoded) {
+    return
+}
+
+HashMap<String, List<DomainCredentials>> credentialsList;
+
+// The message is decoded and unmarshaled
+for (slice in encoded) {
+    def decoded = new String(Base64.decode(slice.chars))
+    domainListByFolders = new XStream2().fromXML(decoded) as HashMap<String, List<DomainCredentials>>  ;  
+}
+
+def instance = Jenkins.get()
+def folderExtension = instance.getExtensionList(FolderCredentialsProvider.class)
+if (!folderExtension.empty) {
+  def folders = instance.getAllItems(Folder.class)
+  def folderProvider = folderExtension.first()
+  def store
+  def domainName
+  for (folder in folders) {
+    store = folderProvider.getStore(folder)
+    folderDomains = domainListByFolders.get(store.getContext().getFullDisplayName())
+    if (folderDomains!=null) {
+      for (domain in folderDomains) {
+        domainName = domain.getDomain().isGlobal() ? "Global":domain.getDomain().getName()
+        println "Updating domain " + domainName
+        for (credential in domain.credentials) {
+            println "   Updating credential: " + credential.id;
+            println store.updateCredentials(domain.getDomain(), credential, credential)
+        }
+      }
+    }
+  }
+}

--- a/credentials-migration/update-credentials-system-level.groovy
+++ b/credentials-migration/update-credentials-system-level.groovy
@@ -28,7 +28,7 @@ for (slice in encoded) {
         println "Updating domain: " + domainName
         for (credential in domain.credentials) {
             println "   Updating credential: ${credential.id}"
-            println store.updateCredentials(domain.getDomain(), credential, credential)
+            store.updateCredentials(domain.getDomain(), credential, credential)
         }
     }
 }

--- a/credentials-migration/update-credentials-system-level.groovy
+++ b/credentials-migration/update-credentials-system-level.groovy
@@ -1,0 +1,34 @@
+/*
+Author: Félix Belzunce Arcos
+Since: January 2021
+Description: Decode from export-credentials-root-level.groovy script, all the credentials of a Jenkins Master at System level. Paste the encoded message output from the export-credentials-root-level.groovy script as the value in the encoded variable in this script and execute it in the Script Console on the destination Jenkins. All the credentials and domains at root level from the source Jenkins will now be updated.
+*/
+
+import com.cloudbees.plugins.credentials.SystemCredentialsProvider
+import com.cloudbees.plugins.credentials.domains.DomainCredentials
+import com.trilead.ssh2.crypto.Base64
+import hudson.util.XStream2
+import jenkins.model.Jenkins
+
+// Paste the encoded message from the script on the source Jenkins
+def encoded = []
+if (!encoded) {
+    return
+}
+
+// The message is decoded and unmarshaled
+for (slice in encoded) {
+    def decoded = new String(Base64.decode(slice.chars))
+    def list = new XStream2().fromXML(decoded) as List<DomainCredentials>
+    // Put all the domains from the list into system credentials
+    def store = Jenkins.get().getExtensionList(SystemCredentialsProvider.class).first().getStore()
+    def domainName
+    for (domain in list) {
+        domainName = domain.getDomain().isGlobal() ? "Global":domain.getDomain().getName()
+        println "Updating domain: " + domainName
+        for (credential in domain.credentials) {
+            println "   Updating credential: ${credential.id}"
+            println store.updateCredentials(domain.getDomain(), credential, credential)
+        }
+    }
+}


### PR DESCRIPTION
The following scripts are intended to help users to update their credentials in the new Jenkins Master when a Monholitic master is splitted.

These scripts are based on https://github.com/cloudbees/cloudbees-examples/tree/master/cloudbees-ci/cje-to-ci-migration-examples/CredentialsMigration. The reason why I am modifying them is that those scripts were mainly created to migrate credentials at the Operations Center level (it is expected not to have any credentials in any master), but in this use case, we are migrating credentials at Master level since we are splitting a Master.

These scripts not only migrate the credentials at the root/system level, but also at the folder level.

I test it with 500 username/password credentials + 500 ssh credentials type and it worked. I guess there is a limit which is the limit for a variable of Groovy for the encoded message. It might fail in cases where users have big secret files in secret text credential type.