### PR TITLE
Credential import can exceed groovy string limit of 65535

### DIFF
--- a/credentials-migration/update-credentials-folder-level.groovy
+++ b/credentials-migration/update-credentials-folder-level.groovy
@@ -24,6 +24,9 @@ import com.cloudbees.plugins.credentials.Credentials
 
 // Paste the encoded message from the script on the source Jenkins
 def encoded=[]
+// If you encounter the error "String too long. The given string is X Unicode code units long, but only a maximum of 65535 is allowed." when running this script,
+// save the encoded data to a file, such as /home/jenkins/credentials.txt, omitting the starting [" and ending "], and un-comment the following line:
+// encoded = [new File("/home/jenkins/credentials.txt").text]
 
 if (!encoded) {
     return

--- a/credentials-migration/update-credentials-system-level.groovy
+++ b/credentials-migration/update-credentials-system-level.groovy
@@ -12,6 +12,9 @@ import jenkins.model.Jenkins
 
 // Paste the encoded message from the script on the source Jenkins
 def encoded = []
+// If you encounter the error "String too long. The given string is X Unicode code units long, but only a maximum of 65535 is allowed." when running this script,
+// save the encoded data to a file, such as /home/jenkins/credentials.txt, omitting the starting [" and ending "], and un-comment the following line:
+// encoded = [new File("/home/jenkins/credentials.txt").text]
 if (!encoded) {
     return
 }


### PR DESCRIPTION
Some clients that have a large number of credentials on their controller, or many ssh credentials, can exceed the groovy string limit of 65535, and the credential import will fail.
If we save the encoded value to a file and load that file using the `File` class, it works around this limitation, and allows me to import the credentials.