### PR TITLE
[CE-6555] Credential migration: Add error checking and account for credentials not already existing

### DIFF
--- a/credentials-migration/update-credentials-folder-level.groovy
+++ b/credentials-migration/update-credentials-folder-level.groovy
@@ -57,7 +57,11 @@ if (!folderExtension.empty) {
         println "   Updating domain " + domainName
         for (credential in domain.credentials) {
             println "     Updating credential: " + credential.id;
-            store.updateCredentials(domain.getDomain(), credential, credential)
+            if (! store.updateCredentials(domain.getDomain(), credential, credential) ){
+                if (! store.addCredentials(domain.getDomain(), credential) ){
+                    println "ERROR: Unable to add credential ${credential.id}"
+                }
+            }
         }
       }
     }

--- a/credentials-migration/update-credentials-system-level.groovy
+++ b/credentials-migration/update-credentials-system-level.groovy
@@ -31,7 +31,11 @@ for (slice in encoded) {
         println "Updating domain: " + domainName
         for (credential in domain.credentials) {
             println "   Updating credential: ${credential.id}"
-            store.updateCredentials(domain.getDomain(), credential, credential)
+            if (! store.updateCredentials(domain.getDomain(), credential, credential) ){
+                if (! store.addCredentials(domain.getDomain(), credential) ){
+                    println "ERROR: Unable to add credential ${credential.id}"
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
When working with a client migrating credentials from an operations center version [2.164.3.2 to 2.289.1.2](https://docs.cloudbees.com/docs/release-notes/latest/cloudbees-ci/), we found that if the credentials did not already exist on the target operations center, the credentials would not be created.

This new code checks the return code from [updateCredentials()](https://javadoc.jenkins.io/plugin/credentials/com/cloudbees/plugins/credentials/CredentialsStore.html#updateCredentials-com.cloudbees.plugins.credentials.domains.Domain-com.cloudbees.plugins.credentials.Credentials-com.cloudbees.plugins.credentials.Credentials-) and if that fails, it will call [addCredentials()](https://javadoc.jenkins.io/plugin/credentials/com/cloudbees/plugins/credentials/CredentialsStore.html#addCredentials-com.cloudbees.plugins.credentials.domains.Domain-com.cloudbees.plugins.credentials.Credentials-), and if both fail, it will let you know (previously the script would not tell you if the migration worked or not).

I've tested that this code allows you to migrate credentials from version 2.164.3.2 to 2.289.1.2, as well as between 2.289.1.2 to  another instance running the same version.