### PR TITLE
automatically refresh update center data to clear the error under "Manage Plugins" without manual steps

### DIFF
--- a/uc-certificate-fix/ucCertRemediation.groovy
+++ b/uc-certificate-fix/ucCertRemediation.groovy
@@ -349,6 +349,8 @@ if (result.equals("NO_CHANGE_NEEDED")) {
 } else if (result.equals("DISABLED_CERT_VALIDATION") || result.equals("REMOVED_OFFLINE_UC")) {
     println("persisting script");
     writeScriptToInitGroovyFolder(_script);
+    println("Reloading update center data");
+    Jenkins.getInstance().pluginManager.doCheckUpdatesServer();
 } else if (result.equals("UNINSTALLED_SCRIPT")) {
     println("No issues detected, script has been uninstalled");
 } else {

--- a/uc-certificate-fix/ucCertRemediation.groovy
+++ b/uc-certificate-fix/ucCertRemediation.groovy
@@ -351,7 +351,7 @@ if (result.equals("NO_CHANGE_NEEDED")) {
     writeScriptToInitGroovyFolder(_script);
     println("Reloading update center data");
     Jenkins.getInstance().pluginManager.doCheckUpdatesServer();
-    println("The remediation is now complete and sucessful");
+    println("The remediation is now complete and successful");
 } else if (result.equals("UNINSTALLED_SCRIPT")) {
     println("No issues detected, script has been uninstalled");
 } else {

--- a/uc-certificate-fix/ucCertRemediation.groovy
+++ b/uc-certificate-fix/ucCertRemediation.groovy
@@ -351,6 +351,7 @@ if (result.equals("NO_CHANGE_NEEDED")) {
     writeScriptToInitGroovyFolder(_script);
     println("Reloading update center data");
     Jenkins.getInstance().pluginManager.doCheckUpdatesServer();
+    println("The remediation is now complete and sucessful");
 } else if (result.equals("UNINSTALLED_SCRIPT")) {
     println("No issues detected, script has been uninstalled");
 } else {


### PR DESCRIPTION
The error due to https://support.cloudbees.com/hc/en-us/articles/4408359898011 does not go away right after you run this script. Either you can wait for the next periodic plugin update site check, or you can go to "Manage Jenkins" -> "Manage  Plugins" and scale the text small enough to be able to click the ‘check now’ button.

This PR is to make it so the update center data is refreshed after the offline update site has been removed, so the error will be gone from "Manage Jenkins" -> "Manage  Plugins" after running the script.

Tested with CloudBees CI on Traditional Platforms Client Controller 2.303.2.5