### PR TITLE
Add the offline update center path for CloudBees CI on Modern Cloud Platforms

### DIFF
--- a/uc-certificate-fix/ucCertRemediation.groovy
+++ b/uc-certificate-fix/ucCertRemediation.groovy
@@ -90,6 +90,7 @@ _dry_run = false;
 _version = "00003";
 _online_uc_url_prefix = "https://jenkins-updates.cloudbees.com/update-center/";
 _offline_uc_url = "file:" + Jenkins.getInstance().getRootDir() + File.separator + "war" + File.separator + "WEB-INF" + File.separator + "plugins" + File.separator + "update-center.json";
+_offline_uc_url_modern = "file:" + File.separator + "tmp" + File.separator + "jenkins" + File.separator + "war" + File.separator + "WEB-INF" + File.separator + "plugins" + File.separator + "update-center.json";
 _retry_time = 30000;   // how long to wait before checking for an update site to be loaded
 _cert_error_str = "CertificateExpiredException: NotAfter: Tue Oct 19 14:31:36 EDT 2021";
 
@@ -309,7 +310,7 @@ def getDefaultOfflineUC() {
 def getDefaultOfflineUC(int retryTime) {
     PersistedList <UpdateSite> sites = Jenkins.getInstance().getUpdateCenter().getSites();
     for (UpdateSite s: sites) {
-        if (s.getUrl().equals(_offline_uc_url)) {
+        if (s.getUrl().equals(_offline_uc_url) || s.getUrl().equals(_offline_uc_url_modern)) {
             debug("Found default offline updatecenter " +s.getUrl());
             return s;
         }
@@ -320,7 +321,7 @@ def getDefaultOfflineUC(int retryTime) {
         Thread.sleep(retryTime);
         for (UpdateSite s: sites) {
             debug("checking " + s.getUrl());
-            if (s.getUrl().equals(_offline_uc_url)) {
+            if (s.getUrl().equals(_offline_uc_url) || s.getUrl().equals(_offline_uc_url_modern)) {
                 debug("Found default offline updatecenter " +s.getUrl() + " on second attempt");
                 return s;
             }

--- a/uc-certificate-fix/ucCertRemediation.groovy
+++ b/uc-certificate-fix/ucCertRemediation.groovy
@@ -87,7 +87,7 @@ _dry_run = false;
 
 //Constants - do not edit below this line
 // ----------------------------------------------------------------------------------------------------
-_version = "00003";
+_version = "00004";
 _online_uc_url_prefix = "https://jenkins-updates.cloudbees.com/update-center/";
 _offline_uc_url = "file:" + Jenkins.getInstance().getRootDir() + File.separator + "war" + File.separator + "WEB-INF" + File.separator + "plugins" + File.separator + "update-center.json";
 _offline_uc_url_modern = "file:" + File.separator + "tmp" + File.separator + "jenkins" + File.separator + "war" + File.separator + "WEB-INF" + File.separator + "plugins" + File.separator + "update-center.json";


### PR DESCRIPTION
Without this fix, when running the script on CloudBees CI on Modern Cloud Platforms it will fail to find the offline update center:

```
INFO: default offline updatecenter was not found, if this is not expected you may need to increase the value for _retry_time
Default offline UC was not found, if this was not expected you may need to increase "_retry_time"
```

After this fix, running this script (system clock is set to the correct time, Oct 18th) results in:

```
INFO: Executing remediation check [v00003]
INFO: Running bootstrap install, disabling retry interval
INFO: Checking if certificate validation is already disabled
INFO: Checking offline update center certificates...
INFO: Offline update center is ok, no update needed
INFO: /var/jenkins_home/init.groovy.d/ucCertRemediation.groovy not found, skipping uninstall
System is up to date, no changes needed
```