### PR TITLE
fix syntax error for offline update center checking

### DIFF
--- a/uc-certificate-fix/ucCertRemediation.groovy
+++ b/uc-certificate-fix/ucCertRemediation.groovy
@@ -98,7 +98,7 @@ _dry_run = false;
 
 //Constants - do not edit below this line
 // ----------------------------------------------------------------------------------------------------
-_version = "00008";
+_version = "00009";
 
 _online_uc_url_prefix = "https://jenkins-updates.cloudbees.com/update-center/";
 _retry_time = 30000;   // how long to wait before checking for an update site to be loaded
@@ -320,7 +320,7 @@ def getDefaultOfflineUC() {
 def getDefaultOfflineUC(int retryTime) {
     PersistedList <UpdateSite> sites = Jenkins.getInstance().getUpdateCenter().getSites();
     for (UpdateSite s: sites) {
-        if (s.getId().contains("-offline") {
+        if (s.getId().contains("-offline")) {
             debug("Found default offline updatecenter " +s.getUrl());
             return s;
         }
@@ -331,7 +331,7 @@ def getDefaultOfflineUC(int retryTime) {
         Thread.sleep(retryTime);
         for (UpdateSite s: sites) {
             debug("checking " + s.getUrl());
-            if (s.getId().contains("-offline") {
+            if (s.getId().contains("-offline")) {
                 debug("Found default offline updatecenter " +s.getUrl() + " on second attempt");
                 return s;
             }


### PR DESCRIPTION
Before this change, the remediation script would  fail to run with:

```
org.codehaus.groovy.control.MultipleCompilationErrorsException: startup failed:
Script1.groovy: 252: expecting ')', found '}' @ line 252, column 5.
       }
       ^

1 error
```