### PR TITLE
Make the success message more understandable if you don't have an offline update center

### DIFF
--- a/uc-certificate-fix/ucCertRemediation.groovy
+++ b/uc-certificate-fix/ucCertRemediation.groovy
@@ -98,7 +98,7 @@ _dry_run = false;
 
 //Constants - do not edit below this line
 // ----------------------------------------------------------------------------------------------------
-_version = "00009";
+_version = "00010";
 
 _online_uc_url_prefix = "https://jenkins-updates.cloudbees.com/update-center/";
 _retry_time = 30000;   // how long to wait before checking for an update site to be loaded


### PR DESCRIPTION
I had a CloudBees client run the script when their controller did not have an offline update center,  and the script reported:

> SUCCESS: The remediation appears to have already been run successfully in the past

But they had not run the script before  on that instance.

This change makes the success message more accurate.