### PR TITLE
Add export/update FileCredentials support

### DIFF
--- a/credentials-migration/export-credentials-folder-level.groovy
+++ b/credentials-migration/export-credentials-folder-level.groovy
@@ -18,8 +18,10 @@ import com.thoughtworks.xstream.io.HierarchicalStreamReader
 import com.thoughtworks.xstream.io.HierarchicalStreamWriter
 import com.trilead.ssh2.crypto.Base64
 import hudson.util.Secret
+import com.cloudbees.plugins.credentials.SecretBytes
 import hudson.util.XStream2
 import jenkins.model.Jenkins
+import java.nio.charset.StandardCharsets
 
 def instance = Jenkins.get()
 def credentials = []
@@ -61,14 +63,31 @@ def converter = new Converter() {
     @Override
     boolean canConvert(Class type) { type == Secret.class }
 }
+// This converter ensure that the output XML contains plain-text for secretBytes (FileCredentials)
+def converterSecretBytes = new Converter() {
+    @Override
+    void marshal(Object object, HierarchicalStreamWriter writer, MarshallingContext context) {
+        writer.value = Base64.encode(new String(object.getPlainData(), StandardCharsets.UTF_8).bytes);
+    }
+
+    @Override
+    Object unmarshal(HierarchicalStreamReader reader, UnmarshallingContext context) { 
+        return SecretBytes.fromBytes(new String(Base64.decode(reader.getValue().toCharArray())).getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Override
+    boolean canConvert(Class type) { type == SecretBytes.class }
+}
 
 def stream = new XStream2()
 stream.registerConverter(converter)
+stream.registerConverter(converterSecretBytes)
 
 // Marshal the list of credentials into XML
 def encoded = []
 
-    def xml = Base64.encode(stream.toXML(domainsFromFolders).bytes)
-    encoded.add("\"${xml}\"")
+//println stream.toXML(domainsFromFolders); return ""; //For debug purpose
+def xml = Base64.encode(stream.toXML(domainsFromFolders).bytes)
+encoded.add("\"${xml}\"")
 
 println encoded.toString()

--- a/credentials-migration/export-credentials-system-level.groovy
+++ b/credentials-migration/export-credentials-system-level.groovy
@@ -17,8 +17,10 @@ import com.thoughtworks.xstream.io.HierarchicalStreamReader
 import com.thoughtworks.xstream.io.HierarchicalStreamWriter
 import com.trilead.ssh2.crypto.Base64
 import hudson.util.Secret
+import com.cloudbees.plugins.credentials.SecretBytes
 import hudson.util.XStream2
 import jenkins.model.Jenkins
+import java.nio.charset.StandardCharsets
 
 def instance = Jenkins.get()
 def credentials = []
@@ -48,9 +50,25 @@ def converter = new Converter() {
     @Override
     boolean canConvert(Class type) { type == Secret.class }
 }
+// This converter ensure that the output XML contains plain-text for secretBytes (FileCredentials)
+def converterSecretBytes = new Converter() {
+    @Override
+    void marshal(Object object, HierarchicalStreamWriter writer, MarshallingContext context) {
+        writer.value = Base64.encode(new String(object.getPlainData(), StandardCharsets.UTF_8).bytes);
+    }
+
+    @Override
+    Object unmarshal(HierarchicalStreamReader reader, UnmarshallingContext context) { 
+        return SecretBytes.fromBytes(new String(Base64.decode(reader.getValue().toCharArray())).getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Override
+    boolean canConvert(Class type) { type == SecretBytes.class }
+}
 
 def stream = new XStream2()
 stream.registerConverter(converter)
+stream.registerConverter(converterSecretBytes)
 
 // Marshal the list of credentials into XML
 def encoded = []

--- a/credentials-migration/update-credentials-system-level.groovy
+++ b/credentials-migration/update-credentials-system-level.groovy
@@ -6,9 +6,14 @@ Description: Decode from export-credentials-root-level.groovy script, all the cr
 
 import com.cloudbees.plugins.credentials.SystemCredentialsProvider
 import com.cloudbees.plugins.credentials.domains.DomainCredentials
+import com.thoughtworks.xstream.converters.Converter
+import com.thoughtworks.xstream.converters.MarshallingContext
+import com.thoughtworks.xstream.converters.UnmarshallingContext
 import com.trilead.ssh2.crypto.Base64
 import hudson.util.XStream2
+import com.cloudbees.plugins.credentials.SecretBytes
 import jenkins.model.Jenkins
+import java.nio.charset.StandardCharsets
 
 // Paste the encoded message from the script on the source Jenkins
 def encoded = []
@@ -19,10 +24,28 @@ if (!encoded) {
     return
 }
 
+// This converter ensure that the output XML contains plain-text for secretBytes (FileCredentials)
+def converterSecretBytes = new Converter() {
+    @Override
+    void marshal(Object object, HierarchicalStreamWriter writer, MarshallingContext context) {
+        writer.value = Base64.encode(new String(object.getPlainData(), StandardCharsets.UTF_8).bytes);
+    }
+
+    @Override
+    Object unmarshal(HierarchicalStreamReader reader, UnmarshallingContext context) { 
+        return SecretBytes.fromBytes(new String(Base64.decode(reader.getValue().toCharArray())).getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Override
+    boolean canConvert(Class type) { type == SecretBytes.class }
+}
+
 // The message is decoded and unmarshaled
 for (slice in encoded) {
     def decoded = new String(Base64.decode(slice.chars))
-    def list = new XStream2().fromXML(decoded) as List<DomainCredentials>
+    def stream = new XStream2()
+    stream.registerConverter(converterSecretBytes)
+    def list = stream.fromXML(decoded) as List<DomainCredentials>
     // Put all the domains from the list into system credentials
     def store = Jenkins.get().getExtensionList(SystemCredentialsProvider.class).first().getStore()
     def domainName


### PR DESCRIPTION
Actually the script for credentials-migration doesn't fully support FileCredential type. That type of credential are exported as a SecretBytes (encrypted with master key of Jenkins source instance) and imported as SecretBytes generated by the already encrypted value...resulting in corrupted file.

I added a new Converter that handle the marshal/unmarshal operation of SecretBytes. 
The file content is encoded in base64.