### PR TITLE
[BEE-35262] Relocate master-provisioning-kubernetes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,6 +8,10 @@
     <artifactId>jenkins-groovy</artifactId>
     <version>1.0-SNAPSHOT</version>
 
+    <properties>
+        <operations-center.version>3.0.34</operations-center.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.jenkins-ci.main</groupId>
@@ -47,12 +51,12 @@
         <dependency>
             <groupId>com.cloudbees.operations-center.common</groupId>
             <artifactId>operations-center-context</artifactId>
-            <version>1.8.9</version>
+            <version>${operations-center.version}</version>
         </dependency>
         <dependency>
             <groupId>com.cloudbees.operations-center.server</groupId>
             <artifactId>operations-center-server</artifactId>
-            <version>1.8.12</version>
+            <version>${operations-center.version}</version>
         </dependency>
         <dependency>
             <groupId>com.coravy.hudson.plugins.github</groupId>
@@ -72,20 +76,14 @@
 
         <dependency>
             <groupId>com.cloudbees.tiger.plugins</groupId>
-            <artifactId>master-provisioning-core</artifactId>
-            <version>2.5.9</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.cloudbees.tiger.plugins</groupId>
             <artifactId>master-provisioning-mesos</artifactId>
             <version>2.5.9</version>
         </dependency>
 
         <dependency>
-            <groupId>com.cloudbees.tiger.plugins</groupId>
+            <groupId>com.cloudbees.operations-center.common</groupId>
             <artifactId>master-provisioning-kubernetes</artifactId>
-            <version>2.5.9</version>
+            <version>${operations-center.version}</version>
         </dependency>
         
         <dependency>


### PR DESCRIPTION
As `master-provisioning-kubernetes` was integrated to OC monorepo:
* moved from `com.cloudbees.tiger.plugins` groupId to `com.cloudbees.operations-center.common`
* aligned with `operations-center` version