### PR TITLE
Scripts to disable and reenable CLI without a restart.

### DIFF
--- a/cli-disable-enable/README.md
+++ b/cli-disable-enable/README.md
@@ -1,5 +1,5 @@
 # CLI Disable/Enable Scripts
-This repository contains scripts to disable and enable the Command Line Interface (CLI) access over HTTP/Websocket and SSH without having to perform a restart every time that we want to reenable. 
+This folder contains scripts to disable and enable the Command Line Interface (CLI) access over HTTP/Websocket and SSH without having to perform a restart every time that we want to reenable. 
 
 * `cli-toggle-disable.groovy` disables the CLI while storing all needed parameters and objects in memory in the jenkins instance. This way the CLI can be enabled if it's needed temporarily.
 * `cli-toggle-disable-permanent.groovy` writes a copy of the previous script to the post-init folder of the jenkins, so that it is always run on start-up and CLI is disabled but ready te reenabled if needed.

--- a/cli-disable-enable/README.md
+++ b/cli-disable-enable/README.md
@@ -1,0 +1,12 @@
+# CLI Disable/Enable Scripts
+This repository contains scripts to disable and enable the Command Line Interface (CLI) access over HTTP/Websocket and SSH without having to perform a restart every time that we want to reenable. 
+
+* `cli-toggle-disable.groovy` disables the CLI while storing all needed parameters and objects in memory in the jenkins instance. This way the CLI can be enabled if it's needed temporarily.
+* `cli-toggle-disable-permanent.groovy` writes a copy of the previous script to the post-init folder of the jenkins, so that it is always run on start-up and CLI is disabled but ready te reenabled if needed.
+* `cli-toggle-enable.groovy` enables the CLI again restoring the previously saved configuration. This should only be done to perform a specific action and then run the disabling script again.
+
+These can be easily run as cluster operations in the same way that it's possible to do with [Disable Jenkins CLI across all controllers](https://docs.cloudbees.com/docs/cloudbees-ci-kb/latest/operations-center/disable-jenkins-cli-across-all-controllers "Disable Jenkins CLI across all controllers") but using tthe scripts defined here instead.
+
+
+Please note that these are just a hacky workaround and not intended for long-term usage. If you are impacted by [CloudBees Security Advisory 2024-01-24](https://www.cloudbees.com/security-advisories/cloudbees-security-advisory-2024-01-24 "CloudBees Security Advisory 2024-01-24") you should upgrade your system as soon as possible.
+

--- a/cli-disable-enable/cli-toggle-disable-permanent.groovy
+++ b/cli-disable-enable/cli-toggle-disable-permanent.groovy
@@ -9,7 +9,7 @@ if (!Files.exists(initDirPath)) {
     Files.createDirectories(initDirPath);
 }
 
-def groovyFile = initDirPath.toRealPath().toString() + "/cli-shutdown.groovy"
+def groovyFile = initDirPath.toRealPath().toString() + "/cli-toggle-disable.groovy"
 
 def codestr="""
 // disable CLI access over HTTP / Websocket
@@ -33,6 +33,14 @@ def archiveThenRemove = { lst ->
 }
 
 def j = jenkins.model.Jenkins.get();
+
+try {
+  if (j.extensionListsMap != null && !j.extensionListsMap.isEmpty() ) {
+    println "CLI is already disabled"
+    return 
+  }
+} catch (groovy.lang.MissingPropertyException e) {/*Continue*/}
+
 def extensionListsMap = [:]
 extensionLists.each { extension ->
     extensionListsMap[extension.getName()] = archiveThenRemove(j.getExtensionList(extension))
@@ -48,6 +56,8 @@ if (j.getPlugin('sshd')) {
 
 //store disabled lists in a new property of the Jenkins instance
 j.metaClass.extensionListsMap = extensionListsMap
+
+println "CLI disabled"
 """
 
 try {

--- a/cli-disable-enable/cli-toggle-disable-permanent.groovy
+++ b/cli-disable-enable/cli-toggle-disable-permanent.groovy
@@ -1,0 +1,59 @@
+import java.nio.file.Files
+import java.nio.file.Paths
+
+def jenkins_home = Jenkins.get().getRootDir().absolutePath
+def initDirPath = Paths.get(jenkins_home, "init.groovy.d")
+
+if (!Files.exists(initDirPath)) {
+    println "Creating Post-Initialization directory '${initDirPath}'..."
+    Files.createDirectories(initDirPath);
+}
+
+def groovyFile = initDirPath.toRealPath().toString() + "/cli-shutdown.groovy"
+
+def codestr="""
+// disable CLI access over HTTP / Websocket
+
+def extensionLists = [
+  hudson.cli.CLIAction.class,
+  hudson.ExtensionPoint.class,
+  hudson.model.Action.class,
+  hudson.model.ModelObject.class,
+  hudson.model.RootAction.class,
+  hudson.model.UnprotectedRootAction.class,
+  java.lang.Object.class,
+  org.kohsuke.stapler.StaplerProxy.class,
+  hudson.model.Action.class
+]
+
+def archiveThenRemove = { lst ->
+    def archive = lst.findAll { it.getClass().getName()?.contains("CLIAction") }
+    lst.removeAll(archive)
+    return archive
+}
+
+def j = jenkins.model.Jenkins.get();
+def extensionListsMap = [:]
+extensionLists.each { extension ->
+    extensionListsMap[extension.getName()] = archiveThenRemove(j.getExtensionList(extension))
+}
+extensionListsMap["actions"] = archiveThenRemove(j.actions)
+
+
+// disable CLI access over SSH
+if (j.getPlugin('sshd')) {
+  extensionListsMap["sshd_port"] = hudson.ExtensionList.lookupSingleton(org.jenkinsci.main.modules.sshd.SSHD.class).getPort()
+  hudson.ExtensionList.lookupSingleton(org.jenkinsci.main.modules.sshd.SSHD.class).setPort(-1)
+}
+
+//store disabled lists in a new property of the Jenkins instance
+j.metaClass.extensionListsMap = extensionListsMap
+"""
+
+try {
+    println "Creating Post-Initialization script '${groovyFile}'..."
+    File file = new File(groovyFile)
+    file.newWriter().withWriter {it << codestr};
+} catch (Exception ex) {
+    println "Unable to create '$groovyFile': " + ex.getMessage() + ". If instance restarts, this script must be applied again"
+}

--- a/cli-disable-enable/cli-toggle-disable.groovy
+++ b/cli-disable-enable/cli-toggle-disable.groovy
@@ -1,0 +1,37 @@
+// disable CLI access over HTTP / Websocket
+
+def extensionLists = [
+  hudson.cli.CLIAction.class,
+  hudson.ExtensionPoint.class,
+  hudson.model.Action.class,
+  hudson.model.ModelObject.class,
+  hudson.model.RootAction.class,
+  hudson.model.UnprotectedRootAction.class,
+  java.lang.Object.class,
+  org.kohsuke.stapler.StaplerProxy.class,
+  hudson.model.Action.class
+]
+
+def archiveThenRemove = { lst ->
+    def archive = lst.findAll { it.getClass().getName()?.contains("CLIAction") }
+    lst.removeAll(archive)
+    return archive
+}
+
+def j = jenkins.model.Jenkins.get();
+def extensionListsMap = [:]
+extensionLists.each { extension ->
+    extensionListsMap[extension.getName()] = archiveThenRemove(j.getExtensionList(extension))
+}
+extensionListsMap["actions"] = archiveThenRemove(j.actions)
+
+
+// disable CLI access over SSH
+if (j.getPlugin('sshd')) {
+  extensionListsMap["sshd_port"] = hudson.ExtensionList.lookupSingleton(org.jenkinsci.main.modules.sshd.SSHD.class).getPort()
+  hudson.ExtensionList.lookupSingleton(org.jenkinsci.main.modules.sshd.SSHD.class).setPort(-1)
+}
+
+//store disabled lists in a new property of the Jenkins instance
+j.metaClass.extensionListsMap = extensionListsMap
+

--- a/cli-disable-enable/cli-toggle-disable.groovy
+++ b/cli-disable-enable/cli-toggle-disable.groovy
@@ -19,6 +19,14 @@ def archiveThenRemove = { lst ->
 }
 
 def j = jenkins.model.Jenkins.get();
+
+try {
+  if (j.extensionListsMap != null && !j.extensionListsMap.isEmpty() ) {
+    println "CLI is already disabled"
+    return 
+  }
+} catch (groovy.lang.MissingPropertyException e) {/*Continue*/}
+
 def extensionListsMap = [:]
 extensionLists.each { extension ->
     extensionListsMap[extension.getName()] = archiveThenRemove(j.getExtensionList(extension))
@@ -35,3 +43,4 @@ if (j.getPlugin('sshd')) {
 //store disabled lists in a new property of the Jenkins instance
 j.metaClass.extensionListsMap = extensionListsMap
 
+println "CLI disabled"

--- a/cli-disable-enable/cli-toggle-enable.groovy
+++ b/cli-disable-enable/cli-toggle-enable.groovy
@@ -1,0 +1,35 @@
+
+// re-enable CLI access over HTTP / Websocket
+def extensionLists = [
+  hudson.cli.CLIAction.class,
+  hudson.ExtensionPoint.class,
+  hudson.model.Action.class,
+  hudson.model.ModelObject.class,
+  hudson.model.RootAction.class,
+  hudson.model.UnprotectedRootAction.class,
+  java.lang.Object.class,
+  org.kohsuke.stapler.StaplerProxy.class,
+  hudson.model.Action.class
+]
+
+j = jenkins.model.Jenkins.get();
+def extensionListsMap = j.extensionListsMap
+
+extensionLists.each { extension ->
+    if (extensionListsMap[extension.getName()] != null ) {
+      j.getExtensionList(extension).addAll(extensionListsMap[extension.getName()])
+    }
+}
+
+if (extensionListsMap["actions"] != null) {
+  if (j.actions == null) {
+    j.actions = extensionListsMap["actions"]
+  } else {
+    j.actions.addAll(extensionListsMap["actions"])
+  }
+}
+
+//re-enable CLI access over SSH
+if (j.getPlugin('sshd') && extensionListsMap["sshd_port"] != null) {
+  hudson.ExtensionList.lookupSingleton(org.jenkinsci.main.modules.sshd.SSHD.class).setPort(extensionListsMap["sshd_port"])
+}

--- a/cli-disable-enable/cli-toggle-enable.groovy
+++ b/cli-disable-enable/cli-toggle-enable.groovy
@@ -15,6 +15,11 @@ def extensionLists = [
 j = jenkins.model.Jenkins.get();
 def extensionListsMap = j.extensionListsMap
 
+if (extensionListsMap == null || extensionListsMap.isEmpty()) {
+  println("Not possible to enable CLI. Perhaps it's already enabled?")
+  return
+}
+
 extensionLists.each { extension ->
     if (extensionListsMap[extension.getName()] != null ) {
       j.getExtensionList(extension).addAll(extensionListsMap[extension.getName()])
@@ -33,3 +38,6 @@ if (extensionListsMap["actions"] != null) {
 if (j.getPlugin('sshd') && extensionListsMap["sshd_port"] != null) {
   hudson.ExtensionList.lookupSingleton(org.jenkinsci.main.modules.sshd.SSHD.class).setPort(extensionListsMap["sshd_port"])
 }
+
+j.extensionListsMap.clear()
+println "CLI re-enabled"


### PR DESCRIPTION
These scripts allow to disable the CLI while the Controller is running, and to reenable it again if needed for a temporary need, and then disable again.