### PR TITLE
[SECO-4138] Add support of "Secret file" credential

### DIFF
--- a/credentials-migration/README.md
+++ b/credentials-migration/README.md
@@ -1,6 +1,6 @@
 # Jenkins Credentials Migration
 
-The following scripts are created to migrate the credentials at Root (System) and Folder level from one Jenkins Master to another one.
+The following scripts are created to migrate the credentials at Root (System) and Folder level from one Jenkins controller to another one.
 
 In Jenkins, `$JENKINS_HOME/secrets/master.key` is the secret used to encrypt all the credentials stored on disk. The new instances created will have their own `$JENKINS_HOME/secrets/master.key`, so it is necessary to export/import the credentials to re-encrypt them in the new Jenkins master.
 
@@ -9,7 +9,7 @@ In Jenkins, `$JENKINS_HOME/secrets/master.key` is the secret used to encrypt all
 1. Download the `export-credentials-system-level.groovy` script on [GitHub](https://github.com/cloudbees/jenkins-scripts/tree/master/credentials-migration/export-credentials-system-level.groovy).
 2. Run `export-credentials-system-level.groovy` in the Script Console on the source instance. It will output an encoded message containing a flattened list of all system credentials. Copy that encoded message.
 
-The encoded message will be used later on to export the credentials in the new Jenkins Master.
+The encoded message will be used later on to export the credentials in the new Jenkins controller.
 
 3. Download the `update-credentials-system-level.groovy` on [GitHub](https://github.com/cloudbees/jenkins-scripts/tree/master/credentials-migration/update-credentials-system-level.groovy).
 
@@ -20,7 +20,7 @@ Paste the encoded message output from the `export-credentials-system-level.groov
 1. Download the `export-credentials-folder-level.groovy` script on [GitHub](https://github.com/cloudbees/jenkins-scripts/tree/master/credentials-migration/export-credentials-folder-level.groovy).
 2. Run `export-credentials-folder-level.groovy` in the Script Console on the source instance. It will output an encoded message containing a flattened list of all system credentials. Copy that encoded message.
 
-The encoded message will be used later on to update the credentials in the new Jenkins Master.
+The encoded message will be used later on to update the credentials in the new Jenkins controller.
 
 3. Download the `update-credentials-folder-level.groovy` on [GitHub](https://github.com/cloudbees/jenkins-scripts/tree/master/credentials-migration/update-credentials-folder-level.groovy).
 

--- a/credentials-migration/export-credentials-folder-level.groovy
+++ b/credentials-migration/export-credentials-folder-level.groovy
@@ -54,7 +54,7 @@ def converter = new Converter() {
     void marshal(Object object, HierarchicalStreamWriter writer, MarshallingContext context) {
         switch (object.class) {
             case Secret: writer.value = Secret.toString(object as Secret); break
-            case SecretBytes: writer.value = Base64.getEncoder().encodeToString((object as SecretBytes).getPlainData())
+            case SecretBytes: writer.value = Base64.getEncoder().encodeToString((object as SecretBytes).getPlainData()); break
         }
     }
 

--- a/credentials-migration/export-credentials-system-level.groovy
+++ b/credentials-migration/export-credentials-system-level.groovy
@@ -41,7 +41,7 @@ def converter = new Converter() {
     void marshal(Object object, HierarchicalStreamWriter writer, MarshallingContext context) {
         switch (object.class) {
             case Secret: writer.value = Secret.toString(object as Secret); break
-            case SecretBytes: writer.value = Base64.getEncoder().encodeToString((object as SecretBytes).getPlainData())
+            case SecretBytes: writer.value = Base64.getEncoder().encodeToString((object as SecretBytes).getPlainData()); break
         }
     }
 

--- a/credentials-migration/update-credentials-folder-level.groovy
+++ b/credentials-migration/update-credentials-folder-level.groovy
@@ -6,18 +6,13 @@ Description: Decode from export-credentials-folder-level.groovy script, all the 
 
 import com.cloudbees.hudson.plugins.folder.AbstractFolder
 import com.cloudbees.hudson.plugins.folder.properties.FolderCredentialsProvider
-import com.cloudbees.plugins.credentials.domains.DomainCredentials
 import com.thoughtworks.xstream.converters.Converter
 import com.thoughtworks.xstream.converters.MarshallingContext
 import com.thoughtworks.xstream.converters.UnmarshallingContext
 import com.thoughtworks.xstream.io.HierarchicalStreamReader
 import com.thoughtworks.xstream.io.HierarchicalStreamWriter
-import com.trilead.ssh2.crypto.Base64
 import hudson.util.Secret
-import hudson.util.XStream2
-import jenkins.model.Jenkins
 import com.cloudbees.plugins.credentials.domains.DomainCredentials
-import com.trilead.ssh2.crypto.Base64
 import hudson.util.XStream2
 import jenkins.model.Jenkins
 import com.cloudbees.plugins.credentials.Credentials
@@ -36,7 +31,7 @@ HashMap<String, List<DomainCredentials>> credentialsList;
 
 // The message is decoded and unmarshaled
 for (slice in encoded) {
-    def decoded = new String(Base64.decode(slice.chars))
+    def decoded = new String(Base64.getDecoder().decode(slice))
     domainsFromFolders = new XStream2().fromXML(decoded) as HashMap<String, List<DomainCredentials>>  ;  
 }
 

--- a/credentials-migration/update-credentials-system-level.groovy
+++ b/credentials-migration/update-credentials-system-level.groovy
@@ -6,7 +6,6 @@ Description: Decode from export-credentials-root-level.groovy script, all the cr
 
 import com.cloudbees.plugins.credentials.SystemCredentialsProvider
 import com.cloudbees.plugins.credentials.domains.DomainCredentials
-import com.trilead.ssh2.crypto.Base64
 import hudson.util.XStream2
 import jenkins.model.Jenkins
 
@@ -21,7 +20,7 @@ if (!encoded) {
 
 // The message is decoded and unmarshaled
 for (slice in encoded) {
-    def decoded = new String(Base64.decode(slice.chars))
+    def decoded = new String(Base64.getDecoder().decode(slice))
     def list = new XStream2().fromXML(decoded) as List<DomainCredentials>
     // Put all the domains from the list into system credentials
     def store = Jenkins.get().getExtensionList(SystemCredentialsProvider.class).first().getStore()

--- a/pom.xml
+++ b/pom.xml
@@ -39,11 +39,6 @@
             <version>5.8</version>
         </dependency>
         <dependency>
-            <groupId>com.cloudbees.nectar</groupId>
-            <artifactId>nectar-rbac</artifactId>
-            <version>5.64</version>
-        </dependency>
-        <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-aggregator</artifactId>
             <version>2.0</version>
@@ -90,6 +85,12 @@
             <groupId>com.cloudbees.nectar</groupId>
             <artifactId>nectar-rbac</artifactId>
             <version>5.66</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>credentials</artifactId>
+            <version>2.6.1</version>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
Credential migration scripts are updated to support the "Secret file" credential type. Should also improve support of any credential type that relies on "SecretBytes" instead of "Secret".

Trilead's Base64 utility is replaced with Java standard library implementation.