### PR TITLE
[SECO-4138] Add practical example to export encoded credentials to a file

### DIFF
--- a/credentials-migration/export-credentials-folder-level.groovy
+++ b/credentials-migration/export-credentials-folder-level.groovy
@@ -72,3 +72,8 @@ stream.registerConverter(converter)
 def encoded = []
 encoded.add("\"${Base64.getEncoder().encodeToString(stream.toXML(domainsFromFolders).bytes)}\"")
 println encoded.toString()
+
+// Marshal the list of credentials into XML in a file (parent directories must exist)
+// If you encounter the error "String too long" when using the update-credentials-folder-level.groovy script, then the following should be used to
+// save the encoded data to a file, such as /home/jenkins/folder_credentials.txt:
+// org.codehaus.groovy.runtime.IOGroovyMethods.withStream(Base64.getEncoder().wrap(new File("/home/jenkins/folder_credentials.txt").newOutputStream()), {os -> stream.toXMLUTF8(domainsFromFolders, os)})

--- a/credentials-migration/export-credentials-system-level.groovy
+++ b/credentials-migration/export-credentials-system-level.groovy
@@ -61,5 +61,10 @@ def sections = credentials.collate(25)
 for (section in sections) {
     encoded.add("\"${Base64.getEncoder().encodeToString(stream.toXML(section).bytes)}\"")
 }
-
 println encoded.toString()
+
+
+// Marshal the list of credentials into XML in a file (parent directories must exist and the user running Jenkins must have sufficient permission in the directory)
+// If you encounter the error "String too long" when using the update-credentials-system-level.groovy script, then the following should be used to
+// save the encoded data to a file, such as /home/jenkins/system_credentials.txt:
+// org.codehaus.groovy.runtime.IOGroovyMethods.withStream(Base64.getEncoder().wrap(new File("/home/jenkins/system_credentials.txt").newOutputStream()), {os -> stream.toXMLUTF8(credentials, os)})

--- a/credentials-migration/update-credentials-folder-level.groovy
+++ b/credentials-migration/update-credentials-folder-level.groovy
@@ -20,8 +20,8 @@ import com.cloudbees.plugins.credentials.Credentials
 // Paste the encoded message from the script on the source Jenkins
 def encoded=[]
 // If you encounter the error "String too long. The given string is X Unicode code units long, but only a maximum of 65535 is allowed." when running this script,
-// save the encoded data to a file, such as /home/jenkins/credentials.txt, omitting the starting [" and ending "], and un-comment the following line:
-// encoded = [new File("/home/jenkins/credentials.txt").text]
+// save the encoded data to a file, such as /home/jenkins/folder_credentials.txt, omitting the starting [" and ending "], and un-comment the following line:
+// encoded = [new File("/home/jenkins/folder_credentials.txt").text]
 
 if (!encoded) {
     return

--- a/credentials-migration/update-credentials-system-level.groovy
+++ b/credentials-migration/update-credentials-system-level.groovy
@@ -12,8 +12,8 @@ import jenkins.model.Jenkins
 // Paste the encoded message from the script on the source Jenkins
 def encoded = []
 // If you encounter the error "String too long. The given string is X Unicode code units long, but only a maximum of 65535 is allowed." when running this script,
-// save the encoded data to a file, such as /home/jenkins/credentials.txt, omitting the starting [" and ending "], and un-comment the following line:
-// encoded = [new File("/home/jenkins/credentials.txt").text]
+// save the encoded data to a file, such as /home/jenkins/system_credentials.txt, omitting the starting [" and ending "], and un-comment the following line:
+// encoded = [new File("/home/jenkins/system_credentials.txt").text]
 if (!encoded) {
     return
 }


### PR DESCRIPTION
Add examples of writing output to a local file for credentials migration.