### PR TITLE
Create skipInitiBuildIndex-multibranch.groovy

### DIFF
--- a/skipInitiBuildIndex-multibranch.groovy
+++ b/skipInitiBuildIndex-multibranch.groovy
@@ -1,0 +1,47 @@
+/**
+ * This script is used to enable the build strategy SkipInitialBuildOnFirstIndexingResetRevision for all multibranch projects.
+ * Use Case: Migration of Jobs across CloudBees CI instances to prevent Build Storm.
+ * Requirement: https://docs.cloudbees.com/docs/release-notes/latest/plugins/cloudbees-build-strategies-plugin/ 
+ */
+
+import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject
+import com.cloudbees.jenkins.plugins.buildstrategies.SkipInitialBuildOnFirstIndexingResetRevision
+
+def dryRun = true
+
+
+def enableBuildStrategy(dryRun) {
+    def modifiedCount = 0
+    def emptyCount = 0
+    def nonEmptyCount = 0
+
+    Jenkins.instance.getAllItems(WorkflowMultiBranchProject).each { multibranchProject ->
+		
+        multibranchProject.getSourcesList().each { branchSource ->
+            if (branchSource !=null) { 
+                def buildStrategies = branchSource.getBuildStrategies()
+                if (buildStrategies.isEmpty()) {
+                    if (dryRun){
+                        println "Dryrun: ${multibranchProject.fullName} is a candidate to add Build Strategy."
+                    } else {
+                        branchSource.setBuildStrategies(Arrays.asList(new SkipInitialBuildOnFirstIndexingResetRevision()))
+                        println "Adding Build Strategy SkipInitialBuildOnFirstIndexingResetRevision for ${multibranchProject.fullName}" 
+                        modifiedCount++
+                    }
+                    emptyCount++
+                } else {
+                    println "${multibranchProject.fullName} has already enabled Build Strategy ${buildStrategies}."
+                    nonEmptyCount++
+                }
+            }
+        }
+    }
+    println "===================================================================================="
+    println "Non-empty build strategies count: ${nonEmptyCount}"
+    println "Empty build strategies count: ${emptyCount}"
+    println "Added build strategies SkipInitialBuildOnFirstIndexingResetRevision: ${modifiedCount}"
+    println "===================================================================================="
+}
+
+enableBuildStrategy(dryRun)
+null

--- a/skipInitiBuildIndex-multibranch.groovy
+++ b/skipInitiBuildIndex-multibranch.groovy
@@ -1,5 +1,5 @@
 /**
- * This script is used to enable the build strategy SkipInitialBuildOnFirstIndexingResetRevision for all multibranch projects that have NOT set a Build Strategy definition.
+ * This script is used to enable the build strategy SkipInitialBuildOnFirstIndexingResetRevision for all existing multibranch and organization projects that have NOT set a Build Strategy definition.
  * Use Case: Migration of Jobs across CloudBees CI instances to prevent Build Storm.
  * Requirement: https://docs.cloudbees.com/docs/release-notes/latest/plugins/cloudbees-build-strategies-plugin/
  * Tested on: CloudBees CI 2.462.3.3 
@@ -7,42 +7,78 @@
 
 import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject
 import com.cloudbees.jenkins.plugins.buildstrategies.SkipInitialBuildOnFirstIndexingResetRevision
+import jenkins.branch.OrganizationFolder
 
 def dryRun = true
 
+// Function to enable build strategy
 
 def enableBuildStrategy(dryRun) {
-    def modifiedCount = 0
-    def emptyCount = 0
-    def nonEmptyCount = 0
+    def mPModifiedCount = 0
+    def mPEmptyCount = 0
+    def mPNonEmptyCount = 0
+    def oFModifiedCount = 0
+    def oFEmptyCount = 0
+    def oFNonEmptyCount = 0
 
-    Jenkins.instance.getAllItems(WorkflowMultiBranchProject).each { multibranchProject ->
+    def jenkins = Jenkins.instance
+
+    jenkins.allItems(WorkflowMultiBranchProject).each { multibranchProject ->
 		
         multibranchProject.getSourcesList().each { branchSource ->
             if (branchSource !=null) { 
                 def buildStrategies = branchSource.getBuildStrategies()
                 if (buildStrategies.isEmpty()) {
                     if (dryRun){
-                        println "Dryrun: ${multibranchProject.fullName} is a candidate to add Build Strategy."
+                        println "Dryrun: Multibranch: ${multibranchProject.fullName} is a candidate to add Build Strategy."
                     } else {
                         branchSource.setBuildStrategies(Arrays.asList(new SkipInitialBuildOnFirstIndexingResetRevision()))
-                        println "Adding Build Strategy SkipInitialBuildOnFirstIndexingResetRevision for ${multibranchProject.fullName}" 
-                        modifiedCount++
+                        println "Multibranch: Adding Build Strategy SkipInitialBuildOnFirstIndexingResetRevision for ${multibranchProject.fullName}" 
+                        mPModifiedCount++
+                        multibranchProject.save()
                     }
-                    emptyCount++
+                    mPEmptyCount++
                 } else {
-                    println "${multibranchProject.fullName} has already enabled Build Strategy ${buildStrategies}."
-                    nonEmptyCount++
+                    println "Multibranch: ${multibranchProject.fullName} has already enabled Build Strategy ${buildStrategies}."
+                    mPNonEmptyCount++
                 }
             }
         }
     }
-    println "===================================================================================="
-    println "Non-empty build strategies count: ${nonEmptyCount}"
-    println "Empty build strategies count: ${emptyCount}"
-    println "Added build strategies SkipInitialBuildOnFirstIndexingResetRevision: ${modifiedCount}"
-    println "===================================================================================="
+
+    jenkins.allItems(OrganizationFolder).each { orgFolder ->
+            def buildStrategies = orgFolder.getBuildStrategies()
+            if (buildStrategies.isEmpty()) {
+                if (dryRun) {
+                    println "Dryrun: Org Folder: ${orgFolder.fullName} is a candidate to add Build Strategy."
+                } else {
+                    orgFolder.getBuildStrategies().add(new SkipInitialBuildOnFirstIndexingResetRevision())
+                    println "Org Folder: Adding Build Strategy SkipInitialBuildOnFirstIndexingResetRevision for ${orgFolder.fullName}"
+                    oFModifiedCount++
+                    orgFolder.save()
+                }
+                oFEmptyCount++
+            } else {
+                println "Org Folder: ${orgFolder.fullName} has already enabled Build Strategy ${buildStrategies}."
+                oFNonEmptyCount++
+            }
+    }
+
+    println """
+====================================================================================
+TOTALS
+    Multibranch:
+    	Non-empty build strategies count: ${mPNonEmptyCount}
+    	Empty build strategies count: ${mPEmptyCount}
+    	Added build strategies SkipInitialBuildOnFirstIndexingResetRevision: ${mPModifiedCount}
+    Organization Folder:
+    	Non-empty build strategies count: ${oFNonEmptyCount}
+    	Empty build strategies count: ${oFEmptyCount}
+    	Added build strategies SkipInitialBuildOnFirstIndexingResetRevision: ${oFModifiedCount}
+===================================================================================="""
 }
 
+
 enableBuildStrategy(dryRun)
+
 null

--- a/skipInitiBuildIndex-multibranch.groovy
+++ b/skipInitiBuildIndex-multibranch.groovy
@@ -11,8 +11,6 @@ import jenkins.branch.OrganizationFolder
 
 def dryRun = true
 
-// Function to enable build strategy
-
 def enableBuildStrategy(dryRun) {
     def mPModifiedCount = 0
     def mPEmptyCount = 0

--- a/skipInitiBuildIndex-multibranch.groovy
+++ b/skipInitiBuildIndex-multibranch.groovy
@@ -1,5 +1,5 @@
 /**
- * This script is used to enable the build strategy SkipInitialBuildOnFirstIndexingResetRevision for all multibranch projects.
+ * This script is used to enable the build strategy SkipInitialBuildOnFirstIndexingResetRevision for all multibranch projects that have NOT set a Build Strategy definition.
  * Use Case: Migration of Jobs across CloudBees CI instances to prevent Build Storm.
  * Requirement: https://docs.cloudbees.com/docs/release-notes/latest/plugins/cloudbees-build-strategies-plugin/
  * Tested on: CloudBees CI 2.462.3.3 

--- a/skipInitiBuildIndex-multibranch.groovy
+++ b/skipInitiBuildIndex-multibranch.groovy
@@ -1,7 +1,8 @@
 /**
  * This script is used to enable the build strategy SkipInitialBuildOnFirstIndexingResetRevision for all multibranch projects.
  * Use Case: Migration of Jobs across CloudBees CI instances to prevent Build Storm.
- * Requirement: https://docs.cloudbees.com/docs/release-notes/latest/plugins/cloudbees-build-strategies-plugin/ 
+ * Requirement: https://docs.cloudbees.com/docs/release-notes/latest/plugins/cloudbees-build-strategies-plugin/
+ * Tested on: CloudBees CI 2.462.3.3 
  */
 
 import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject


### PR DESCRIPTION
This script ensure all Multibranch pipelines has enabled Initial Index Build Prevention to prevent https://www.cloudbees.com/blog/weathering-build-storms-in-the-enterprise in a clean workspaces.

It is useful for job migration use cases. 