### PR TITLE
Fix: Enhance robustness of file-based Base64 decoding in credential migration scripts

### DIFF
--- a/credentials-migration/update-credentials-folder-level.groovy
+++ b/credentials-migration/update-credentials-folder-level.groovy
@@ -21,7 +21,7 @@ import com.cloudbees.plugins.credentials.Credentials
 def encoded=[]
 // If you encounter the error "String too long. The given string is X Unicode code units long, but only a maximum of 65535 is allowed." when running this script,
 // save the encoded data to a file, such as /home/jenkins/folder_credentials.txt, omitting the starting [" and ending "], and un-comment the following line:
-// encoded = [new File("/home/jenkins/folder_credentials.txt").text]
+// encoded = [new File("/home/jenkins/folder_credentials.txt").text.trim()]
 
 if (!encoded) {
     return

--- a/credentials-migration/update-credentials-system-level.groovy
+++ b/credentials-migration/update-credentials-system-level.groovy
@@ -13,7 +13,7 @@ import jenkins.model.Jenkins
 def encoded = []
 // If you encounter the error "String too long. The given string is X Unicode code units long, but only a maximum of 65535 is allowed." when running this script,
 // save the encoded data to a file, such as /home/jenkins/system_credentials.txt, omitting the starting [" and ending "], and un-comment the following line:
-// encoded = [new File("/home/jenkins/system_credentials.txt").text]
+// encoded = [new File("/home/jenkins/system_credentials.txt").text.trim()]
 if (!encoded) {
     return
 }


### PR DESCRIPTION
Problem Addressed: java.lang.IllegalArgumentException: Illegal base64 character when reading encoded data from file

This PR addresses a common issue encountered when users attempt to load the encoded credentials data from a file (e.g., /home/jenkins/system_credentials.txt), as suggested by the comments in the credential migration scripts.


The Base64.getDecoder().decode() method expects a pure Base64 string. However, when text content is read from a file using new File(...).text, it often includes trailing whitespace or newline characters (e.g., \n, \r\n) that are automatically appended by text editors or file systems. These non-Base64 characters, even if invisible, cause the java.lang.IllegalArgumentException: Illegal base64 character a (or similar, depending on the character) during the decoding process, leading to script failure.


Solution Implemented: Trim whitespace from file content

To prevent this, I've added a .trim() call to the string read from the file in both relevant credential migration scripts. This ensures that any leading or trailing whitespace, including newline characters, is removed before the Base64 decoding attempt.

Testing:
I have tested this change by creating a system_credentials.txt file containing a valid Base64 string followed by a newline character. Before this change, both scripts would fail with the IllegalArgumentException. With the .trim() addition, both scripts successfully decode the content and proceed as expected.

